### PR TITLE
Rename main subcommand from `range` to `run` and change how it computes commits to test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ First define the test that you would like to run; for example,
 
 The string that you specify can be an arbitrary command; it is run with `sh -c`. Its exit code should be 0 if the test passes, or nonzero if it fails. The test definition is stored in your Git config.
 
-### Test a range of commits
+### Test one or more commits
 
-You can test a range of Git commits with a single command:
+You can test multiple Git commits with a single command:
 
     git test run commit1..commit2
 
-The test is run against each commit in the range, in order from old to new. If a commit fails the test, `git test` reports the error and stops with the broken commit checked out.
+The test is run against each commit in the range, in order from old to new. If a commit fails the test, `git test` reports the error and stops with the broken commit checked out. You can also specify individual commits to test:
+
+    git test run commit1 commit2 commit3
 
 ### Define multiple tests
 
@@ -99,8 +101,6 @@ Some other features that would be nice:
 
 *   Be more consistent about restoring `HEAD`. `git test run` currently checks out the branch that you started on when it is finished, but only if all of the tests passed. We need some kind of `git test reset` command analogous to `git bisect reset`.
 
-*   `git test run`, to run a test on a single commit.
-
 *   Allow tests to be run against a dirty working tree (i.e., against uncommitted changes). Perhaps don't record the test results at all in this case. Perhaps, if all changes in the working tree are staged, record the test results against the tree SHA-1 of the staged changes.
 
 *   `git test bisect`: run `git bisect run` against a range of commits, using a configured test as the command that `bisect` uses to decide whether a commit is good/bad.
@@ -123,12 +123,10 @@ Some other features that would be nice:
 
 *   Add a subcommand to list known results for a commit range in machine-readable format.
 
-*   Handle ranges differently, for example (maybe):
+*   Add some more options for specifying commits, for example (maybe):
 
     *   By default, test up to the "upstream" branch (if it is configured)
-    *   `*..*` -- test specified range
-    *   `*..` -- test between specified commit and `HEAD` (though this is fragile if `HEAD` changes often, like now)
-    *   Otherwise -- test single commit
+    *   `*..` -- test between specified commit and `HEAD` (though this is fragile if `HEAD` changes often, as is currently the case)
     *   `--stdin` -- read commits/trees to test from standard input
     *   `-- [...]` -- pass arbitrary arguments to `git rev-list --reverse`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The best way to use `git test` is to keep a window open in a second linked worktree of your repository, and as often as you like run
 
-    git test range master..mybranch
+    git test run master..mybranch
 
 `git test` will test the commits in that range, reporting any failures. The pass/fail results of running tests are also recorded permanently in your repository as Git "notes" (see `git-notes(1)`).
 
@@ -34,7 +34,7 @@ The string that you specify can be an arbitrary command; it is run with `sh -c`.
 
 You can test a range of Git commits with a single command:
 
-    git test range commit1..commit2
+    git test run commit1..commit2
 
 The test is run against each commit in the range, in order from old to new. If a commit fails the test, `git test` reports the error and stops with the broken commit checked out.
 
@@ -43,17 +43,17 @@ The test is run against each commit in the range, in order from old to new. If a
 You can define multiple tests in a single repository (e.g., cheap vs. expensive tests). Their results are kept separate. By default, the test called `default` is run, but you can specify a different test to add/run using the `--test=<name>`/`-t <name>` option:
 
     git test add "make test"
-    git test range commit1..commit2
+    git test run commit1..commit2
     git test add --test=build "make"
-    git test range --test=build commit1..commit2
+    git test run --test=build commit1..commit2
 
 ### Retrying tests and/or forgetting old test results
 
-If you have flaky tests that occasionally fail for bogus reasons, you might want to re-run the test against a commit even though `git test` has already recorded a result for that commit. To do so, run `git test range` with the `--force`/`-f` or `--retest` options. If you want to forget old test results without retesting (e.g., if you change the test command), use `--forget`.
+If you have flaky tests that occasionally fail for bogus reasons, you might want to re-run the test against a commit even though `git test` has already recorded a result for that commit. To do so, run `git test run` with the `--force`/`-f` or `--retest` options. If you want to forget old test results without retesting (e.g., if you change the test command), use `--forget`.
 
 ### Continue on test failures
 
-Normally, `git test range` stops at the first broken commit that it finds. If you'd prefer for it to continue, use the `--keep-going`/`-k` option.
+Normally, `git test run` stops at the first broken commit that it finds. If you'd prefer for it to continue, use the `--keep-going`/`-k` option.
 
 ### For help
 
@@ -63,11 +63,11 @@ General help about `git test` can be obtained by running
 
 Help about a particular subcommand can be obtained via either
 
-    git test help range
+    git test help run
 
 or
 
-    git test range --help
+    git test run --help
 
 
 ## Best practice: use `git test` in a linked worktree
@@ -76,7 +76,7 @@ or
 
     git worktree add --detach ../test HEAD
     cd ../test
-    git test range master..mybranch
+    git test run master..mybranch
 
 The last command can be re-run any time; it only does significant work when something changes on your branch. Plus, with this setup you can continue to work in your main working tree while the tests run.
 
@@ -97,7 +97,7 @@ Just put `bin/git-test` somewhere in your `$PATH`, adjusting its first line if n
 
 Some other features that would be nice:
 
-*   Be more consistent about restoring `HEAD`. `git test range` currently checks out the branch that you started on when it is finished, but only if all of the tests passed. We need some kind of `git test reset` command analogous to `git bisect reset`.
+*   Be more consistent about restoring `HEAD`. `git test run` currently checks out the branch that you started on when it is finished, but only if all of the tests passed. We need some kind of `git test reset` command analogous to `git bisect reset`.
 
 *   `git test run`, to run a test on a single commit.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The test is run against each commit in the range, in order from old to new. If a
 
     git test run commit1 commit2 commit3
 
+or test an arbitrary set of commits supplied via standard input:
+
+    git rev-list feature1 feature2 ^master | git test run --stdin
+
 ### Define multiple tests
 
 You can define multiple tests in a single repository (e.g., cheap vs. expensive tests). Their results are kept separate. By default, the test called `default` is run, but you can specify a different test to add/run using the `--test=<name>`/`-t <name>` option:
@@ -127,7 +131,6 @@ Some other features that would be nice:
 
     *   By default, test up to the "upstream" branch (if it is configured)
     *   `*..` -- test between specified commit and `HEAD` (though this is fragile if `HEAD` changes often, as is currently the case)
-    *   `--stdin` -- read commits/trees to test from standard input
     *   `-- [...]` -- pass arbitrary arguments to `git rev-list --reverse`
 
 *   Add a `git test fix <range>`, which starts an interactive rebase, changing the command for the first broken commit from "pick" to "edit".

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ The string that you specify can be an arbitrary command; it is run with `sh -c`.
 
 ### Test one or more commits
 
-You can test multiple Git commits with a single command:
+By default, `git test run` tests `HEAD`:
+
+    git test run
+
+(If the working copy is dirty, the test is run anyway but the results are not recorded.)
+
+You can test a range of Git commits with a single command:
 
     git test run commit1..commit2
 
@@ -105,8 +111,6 @@ Some other features that would be nice:
 
 *   Be more consistent about restoring `HEAD`. `git test run` currently checks out the branch that you started on when it is finished, but only if all of the tests passed. We need some kind of `git test reset` command analogous to `git bisect reset`.
 
-*   Allow tests to be run against a dirty working tree (i.e., against uncommitted changes). Perhaps don't record the test results at all in this case. Perhaps, if all changes in the working tree are staged, record the test results against the tree SHA-1 of the staged changes.
-
 *   `git test bisect`: run `git bisect run` against a range of commits, using a configured test as the command that `bisect` uses to decide whether a commit is good/bad.
 
 *   `git test remove`: remove a test definition and its associated notes.
@@ -126,12 +130,6 @@ Some other features that would be nice:
 *   Remember return codes and give them back out if the old result is reused.
 
 *   Add a subcommand to list known results for a commit range in machine-readable format.
-
-*   Add some more options for specifying commits, for example (maybe):
-
-    *   By default, test up to the "upstream" branch (if it is configured)
-    *   `*..` -- test between specified commit and `HEAD` (though this is fragile if `HEAD` changes often, as is currently the case)
-    *   `-- [...]` -- pass arbitrary arguments to `git rev-list --reverse`
 
 *   Add a `git test fix <range>`, which starts an interactive rebase, changing the command for the first broken commit from "pick" to "edit".
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -396,18 +396,37 @@ def uniqify(l):
 
 
 def cmd_run(parser, options):
-    require_clean_work_tree('test-run')
-
     setup_test(options.test)
 
     try:
-        cmd = ['git', 'symbolic-ref', 'HEAD']
-        head = check_output(cmd, stderr=open('/dev/null', 'wb')).rstrip()
-    except CalledProcessError:
-        cmd = ['git', 'rev-parse', 'HEAD']
-        head = check_output(cmd).rstrip()
+        require_clean_work_tree('test-run')
+    except UncleanWorkTreeError:
+        # Unclean work tree; the only action allowed in this state is
+        # testing the working copy:
+        if options.commits or options.stdin or options.forget:
+            raise
+
+        try:
+            test()
+        except UserTestError as e:
+            sys.stdout.write('\n!!! TEST FAILED !!!\n')
+            sys.exit(e.returncode)
+        else:
+            sys.stdout.write('\nTEST SUCCESSFUL\n')
+        finally:
+            sys.stdout.write(
+                'Note: working tree is dirty; results will not be saved.\n'
+                )
+        return
 
     revisions = []
+
+    if options.commits or options.stdin:
+        testing_head = False
+    else:
+        testing_head = True
+        revisions.append(rev_parse('HEAD'))
+
     for arg in options.commits:
         limits = arg.split('..')
         if len(limits) == 1:
@@ -427,6 +446,17 @@ def cmd_run(parser, options):
             )
 
     revisions = list(uniqify(revisions))
+
+    if not revisions:
+        sys.stdout.write('NO COMMITS SPECIFIED! (so none failed)\n')
+        return
+
+    try:
+        cmd = ['git', 'symbolic-ref', 'HEAD']
+        head = check_output(cmd, stderr=open('/dev/null', 'wb')).rstrip()
+    except CalledProcessError:
+        cmd = ['git', 'rev-parse', 'HEAD']
+        head = check_output(cmd).rstrip()
 
     if options.force or options.forget:
         forget_notes(revisions)
@@ -464,7 +494,9 @@ def cmd_run(parser, options):
                     sys.exit(1)
 
         if status == 'unknown':
-            prepare_revision(r)
+            if not testing_head:
+                prepare_revision(r)
+
             try:
                 test_and_record(r)
             except UserTestError as e:
@@ -475,8 +507,9 @@ def cmd_run(parser, options):
                 else:
                     sys.exit(e.returncode)
 
-    cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
-    check_call(cmd)
+    if not testing_head:
+        cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
+        check_call(cmd)
 
     sys.stdout.write('\n')
     if fail_count > 0:

--- a/bin/git-test
+++ b/bin/git-test
@@ -364,8 +364,6 @@ def test_and_record(r):
 def setup_test(name):
     global notes_ref, command
 
-    sys.stdout.write('setup_test %s\n' % (name,))
-
     notes_ref = 'tests/%s' % (name,)
     cmd = ['git', 'config', '--get', 'test.%s.command' % (name,)]
     try:

--- a/bin/git-test
+++ b/bin/git-test
@@ -476,7 +476,10 @@ def main(args):
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-    subparsers = parser.add_subparsers(dest='subcommand', help='sub-command')
+    subparsers = parser.add_subparsers(
+        dest='subcommand', help='sub-command',
+        parser_class=argparse.ArgumentParser,
+        )
 
     subparser = subparsers.add_parser(
         'add',
@@ -495,6 +498,36 @@ def main(args):
         help='command to run',
         )
 
+    def add_run_arguments(subparser):
+        subparser.add_argument(
+            '--test', '-t', metavar='name',
+            action='store', default='default',
+            help='name of test',
+            )
+        subparser.add_argument(
+            '--force', '-f', action='store_true',
+            help='forget any existing test results for the range and test it again',
+            )
+        subparser.add_argument(
+            '--forget', action='store_true',
+            help='forget any existing test results for the range',
+            )
+        subparser.add_argument(
+            '--retest', action='store_true',
+            help='if any commit in the range is marked as "bad", try testing it again',
+            )
+        subparser.add_argument(
+            '--keep-going', '-k', action='store_true',
+            help=(
+                'if a commit fails the test, continue testing other commits '
+                'rather than aborting'
+                ),
+            )
+        subparser.add_argument(
+            'range',
+            help='range of commits to test',
+            )
+
     subparser = subparsers.add_parser(
         'run',
         description=(
@@ -505,34 +538,18 @@ def main(args):
             ),
         help='run a test against a range of commits',
         )
-    subparser.add_argument(
-        '--test', '-t', metavar='name',
-        action='store', default='default',
-        help='name of test',
-        )
-    subparser.add_argument(
-        '--force', '-f', action='store_true',
-        help='forget any existing test results for the range and test it again',
-        )
-    subparser.add_argument(
-        '--forget', action='store_true',
-        help='forget any existing test results for the range',
-        )
-    subparser.add_argument(
-        '--retest', action='store_true',
-        help='if any commit in the range is marked as "bad", try testing it again',
-        )
-    subparser.add_argument(
-        '--keep-going', '-k', action='store_true',
-        help=(
-            'if a commit fails the test, continue testing other commits '
-            'rather than aborting'
-            ),
-        )
-    subparser.add_argument(
+    add_run_arguments(subparser)
+
+    # This command is no longer supported, but emit a help message if
+    # it is requested:
+    subparser = subparsers.add_parser(
         'range',
-        help='range of commits to test',
+        help='obsolete command; please use "git test run" instead',
         )
+    # We need to accept the 'run' options and arguments, otherwise
+    # argparse will emit an error about unrecognized arguments and
+    # abort before we get a chance to emit our help message:
+    add_run_arguments(subparser)
 
     subparser = subparsers.add_parser(
         'help',
@@ -553,6 +570,8 @@ def main(args):
         cmd_add(parser, options)
     elif options.subcommand == 'run':
         cmd_run(parser, options)
+    elif options.subcommand == 'range':
+        parser.error('the \'range\' subcommand has been renamed to \'run\'.')
     elif options.subcommand == 'help':
         cmd_help(parser, options, subparsers)
     else:

--- a/bin/git-test
+++ b/bin/git-test
@@ -379,6 +379,18 @@ def cmd_add(parser, options):
     check_call(cmd)
 
 
+def uniqify(l):
+    """Iterate over the unique items in l, in the original order.
+
+    Yield an item only the first time it is seen."""
+
+    seen = set()
+    for i in l:
+        if i not in seen:
+            yield i
+            seen.add(i)
+
+
 def cmd_run(parser, options):
     require_clean_work_tree('test-run')
 
@@ -403,6 +415,8 @@ def cmd_run(parser, options):
                 'commit arguments must be single commits '
                 'or of the form \'A..B\''
                 )
+
+    revisions = list(uniqify(revisions))
 
     if options.force or options.forget:
         forget_notes(revisions)

--- a/bin/git-test
+++ b/bin/git-test
@@ -30,8 +30,8 @@
   for a particular test are stored in the repository's Git
   configuration.
 
-* Tools for running such tests against single Git commits or against a
-  range of commits.
+* Tools for running such tests against single Git commits or against
+  ranges of commits.
 
 * A scheme for storing the results of such tests as git notes. The
   results are connected to the tree of the commit that was tested, so
@@ -391,7 +391,18 @@ def cmd_run(parser, options):
         cmd = ['git', 'rev-parse', 'HEAD']
         head = check_output(cmd).rstrip()
 
-    revisions = list(rev_list('--reverse', options.range))
+    revisions = []
+    for arg in options.commits:
+        limits = arg.split('..')
+        if len(limits) == 1:
+            revisions.append(rev_parse('%s^{commit}' % (arg,)))
+        elif len(limits) == 2:
+            revisions.extend(rev_list('--reverse', arg))
+        else:
+            parser.error(
+                'commit arguments must be single commits '
+                'or of the form \'A..B\''
+                )
 
     if options.force or options.forget:
         forget_notes(revisions)
@@ -506,15 +517,18 @@ def main(args):
             )
         subparser.add_argument(
             '--force', '-f', action='store_true',
-            help='forget any existing test results for the range and test it again',
+            help=(
+                'forget any existing test results for the specified '
+                'commits and test them again'
+                ),
             )
         subparser.add_argument(
             '--forget', action='store_true',
-            help='forget any existing test results for the range',
+            help='forget any existing test results for the specified commits',
             )
         subparser.add_argument(
             '--retest', action='store_true',
-            help='if any commit in the range is marked as "bad", try testing it again',
+            help='if a commit is already marked as "bad", try testing it again',
             )
         subparser.add_argument(
             '--keep-going', '-k', action='store_true',
@@ -524,8 +538,8 @@ def main(args):
                 ),
             )
         subparser.add_argument(
-            'range',
-            help='range of commits to test',
+            'commits', nargs='+',
+            help='commits or ranges of commits to test',
             )
 
     subparser = subparsers.add_parser(
@@ -534,9 +548,9 @@ def main(args):
             'Run COMMAND for each commit in the specified RANGE in reverse order, '
             'stopping if the command fails.  The return code is that of the last '
             'command executed (i.e., 0 only if the command succeeded for every '
-            'commit in the range).'
+            'specified commit).'
             ),
-        help='run a test against a range of commits',
+        help='run a test against one or more commits',
         )
     add_run_arguments(subparser)
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -416,6 +416,12 @@ def cmd_run(parser, options):
                 'or of the form \'A..B\''
                 )
 
+    if options.stdin:
+        revisions.extend(
+            rev_parse('%s^{commit}' % (arg.strip(),))
+            for arg in sys.stdin
+            )
+
     revisions = list(uniqify(revisions))
 
     if options.force or options.forget:
@@ -552,7 +558,14 @@ def main(args):
                 ),
             )
         subparser.add_argument(
-            'commits', nargs='+',
+            '--stdin', action='store_true',
+            help=(
+                'read the list of commits to test from standard input, '
+                'one per line'
+                ),
+            )
+        subparser.add_argument(
+            'commits', nargs='*',
             help='commits or ranges of commits to test',
             )
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -311,6 +311,19 @@ def forget_notes(revisions):
         raise Fatal('fatal: error removing one or more existing notes')
 
 
+def test():
+    """Test the current contents of the working tree."""
+
+    if command is None:
+        raise Fatal('fatal: no test command configured')
+
+    cmd = ['sh', '-c', command]
+    try:
+        check_call(cmd)
+    except CalledProcessError as e:
+        raise UserTestError(e.returncode, e.cmd, e.output)
+
+
 def test_revision(r):
     cmd = ['git', 'checkout', r]
     try:
@@ -324,14 +337,7 @@ def test_revision(r):
     except CalledProcessError as e:
         raise Fatal('fatal: error displaying log for commit %s' % (r,))
 
-    if command is None:
-        raise Fatal('fatal: no test command configured')
-
-    cmd = ['sh', '-c', command]
-    try:
-        check_call(cmd)
-    except CalledProcessError as e:
-        raise UserTestError(e.returncode, e.cmd, e.output)
+    test()
 
 
 FAIL_HEADER_TEMPLATE = """\

--- a/bin/git-test
+++ b/bin/git-test
@@ -338,11 +338,6 @@ def prepare_revision(r):
         raise Fatal('fatal: error displaying log for commit %s' % (r,))
 
 
-def test_revision(r):
-    prepare_revision(r)
-    test()
-
-
 FAIL_HEADER_TEMPLATE = """\
 
 *******************************************************************************
@@ -357,8 +352,9 @@ FAILURE!
 """
 
 def test_and_record(r):
+    prepare_revision(r)
     try:
-        test_revision(r)
+        test()
     except UserTestError as e:
         cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
         sys.stdout.write(FAIL_HEADER_TEMPLATE % dict(r=r))

--- a/bin/git-test
+++ b/bin/git-test
@@ -324,7 +324,7 @@ def test():
         raise UserTestError(e.returncode, e.cmd, e.output)
 
 
-def test_revision(r):
+def prepare_revision(r):
     cmd = ['git', 'checkout', r]
     try:
         check_call(cmd)
@@ -337,6 +337,9 @@ def test_revision(r):
     except CalledProcessError as e:
         raise Fatal('fatal: error displaying log for commit %s' % (r,))
 
+
+def test_revision(r):
+    prepare_revision(r)
     test()
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -421,11 +421,15 @@ def cmd_run(parser, options):
 
     revisions = []
 
-    if options.commits or options.stdin:
+    if options.stdin:
         testing_head = False
-    else:
-        testing_head = True
+    elif not options.commits:
         revisions.append(rev_parse('HEAD'))
+        testing_head = True
+    elif options.commits == ['HEAD']:
+        testing_head = True
+    else:
+        testing_head = False
 
     for arg in options.commits:
         limits = arg.split('..')

--- a/bin/git-test
+++ b/bin/git-test
@@ -48,7 +48,7 @@ tying up your main repository):
     $ git config test.full.command 'make -j16 test'
     $ git worktree add --detach ../tests feature
     $ cd ../tests
-    $ git test range --test=full master..feature
+    $ git test run --test=full master..feature
 
 Any time you make changes to the feature branch in your main
 repository, you can re-run the last command in the `tests` worktree.
@@ -379,8 +379,8 @@ def cmd_add(parser, options):
     check_call(cmd)
 
 
-def cmd_range(parser, options):
-    require_clean_work_tree('test-range')
+def cmd_run(parser, options):
+    require_clean_work_tree('test-run')
 
     setup_test(options.test)
 
@@ -496,7 +496,7 @@ def main(args):
         )
 
     subparser = subparsers.add_parser(
-        'range',
+        'run',
         description=(
             'Run COMMAND for each commit in the specified RANGE in reverse order, '
             'stopping if the command fails.  The return code is that of the last '
@@ -551,8 +551,8 @@ def main(args):
 
     if options.subcommand == 'add':
         cmd_add(parser, options)
-    elif options.subcommand == 'range':
-        cmd_range(parser, options)
+    elif options.subcommand == 'run':
+        cmd_run(parser, options)
     elif options.subcommand == 'help':
         cmd_help(parser, options, subparsers)
     else:

--- a/bin/git-test
+++ b/bin/git-test
@@ -352,7 +352,6 @@ FAILURE!
 """
 
 def test_and_record(r):
-    prepare_revision(r)
     try:
         test()
     except UserTestError as e:
@@ -465,6 +464,7 @@ def cmd_run(parser, options):
                     sys.exit(1)
 
         if status == 'unknown':
+            prepare_revision(r)
             try:
                 test_and_record(r)
             except UserTestError as e:

--- a/test/add.t
+++ b/test/add.t
@@ -4,60 +4,54 @@ test_description="Test adding and changing test definitions"
 
 . ./sharness.sh
 
-PATH="$(pwd)/../test-helpers:$(pwd)/../bin:$PATH"
-export PATH
-
-SQ="'"
-DQ='"'
-
 test_expect_success 'Set up test repository' '
 	git init .
 '
 
 test_expect_success 'Configure a default test' '
-	git test add "echo foo" &&
+	git-test add "echo foo" &&
 	echo "echo foo" >expected &&
 	git config --get test.default.command >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Change the default test' '
-	git test add "echo bar" &&
+	git-test add "echo bar" &&
 	echo "echo bar" >expected &&
 	git config --get test.default.command >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Configure a different test' '
-	git test add --test=baz "echo baz" &&
+	git-test add --test=baz "echo baz" &&
 	echo "echo baz" >expected &&
 	git config --get test.baz.command >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Change a different test' '
-	git test add --test=baz "echo xyzzy" &&
+	git-test add --test=baz "echo xyzzy" &&
 	echo "echo xyzzy" >expected &&
 	git config --get test.baz.command >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Configure a test that includes single quotes' '
-	git test add --test=sq "echo ${SQ}foo${SQ}" &&
+	git-test add --test=sq "echo ${SQ}foo${SQ}" &&
 	echo "echo ${SQ}foo${SQ}" >expected &&
 	git config --get test.sq.command >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Configure a test that includes double quotes' '
-	git test add --test=dq "echo ${DQ}foo${DQ}" &&
+	git-test add --test=dq "echo ${DQ}foo${DQ}" &&
 	echo "echo ${DQ}foo${DQ}" >expected &&
 	git config --get test.dq.command >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Configure a test that includes newlines' '
-	git test add --test=nl "echo foo${LF}echo bar" &&
+	git-test add --test=nl "echo foo${LF}echo bar" &&
 	echo "echo foo${LF}echo bar" >expected &&
 	git config --get test.nl.command >actual &&
 	test_cmp expected actual

--- a/test/range.t
+++ b/test/range.t
@@ -4,9 +4,6 @@ test_description="Test basic features"
 
 . ./sharness.sh
 
-PATH="$(pwd)/../test-helpers:$(pwd)/../bin:$PATH"
-export PATH
-
 # The test repository consists of a linear chain of numbered commits.
 # Each commit contains a file "number" containing the number of the
 # commit. Each commit is pointed at by a branch "c<number>".
@@ -28,9 +25,9 @@ test_expect_success 'Set up test repository' '
 '
 
 test_expect_success 'default (passing): test range' '
-	git test add "test-number --log=numbers.log --good \*" &&
+	git-test add "test-number --log=numbers.log --good \*" &&
 	rm -f numbers.log &&
-	git test range c2..c6 &&
+	git-test range c2..c6 &&
 	printf "default %s${LF}" 3 4 5 6 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -43,34 +40,34 @@ test_expect_success 'default (passing): test range' '
 
 test_expect_success 'default (passing): do not re-test known-good commits' '
 	rm -f numbers.log &&
-	git test range c3..c5 &&
+	git-test range c3..c5 &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (passing): do not re-test known-good subrange' '
 	rm -f numbers.log &&
-	git test range c1..c7 &&
+	git-test range c1..c7 &&
 	printf "default %s${LF}" 2 7 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): do not retest known-good even with --retest' '
 	rm -f numbers.log &&
-	git test range --retest c0..c8 &&
+	git-test range --retest c0..c8 &&
 	printf "default %s${LF}" 1 8 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): retest with --force' '
 	rm -f numbers.log &&
-	git test range --force c5..c9 &&
+	git-test range --force c5..c9 &&
 	printf "default %s${LF}" 6 7 8 9 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): forget some results' '
 	rm -f numbers.log &&
-	git test range --forget c4..c7 &&
+	git-test range --forget c4..c7 &&
 	test_must_fail test -f numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c5^{tree} &&
 	test_must_fail git notes --ref=tests/default show $c7^{tree}
@@ -78,16 +75,16 @@ test_expect_success 'default (passing): forget some results' '
 
 test_expect_success 'default (passing): retest forgotten commits' '
 	rm -f numbers.log &&
-	git test range c3..c8 &&
+	git-test range c3..c8 &&
 	printf "default %s${LF}" 5 6 7 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): test range' '
 	git update-ref -d refs/notes/tests/default &&
-	git test add "test-number --log=numbers.log --bad 4 7 8 --good \*" &&
+	git-test add "test-number --log=numbers.log --bad 4 7 8 --good \*" &&
 	rm -f numbers.log &&
-	test_expect_code 1 git test range c2..c5 &&
+	test_expect_code 1 git-test range c2..c5 &&
 	printf "default %s${LF}" 3 4 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -100,29 +97,29 @@ test_expect_success 'default (failing-4-7-8): test range' '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known commits' '
 	rm -f numbers.log &&
-	test_expect_code 1 git test range c2..c5 &&
+	test_expect_code 1 git-test range c2..c5 &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known subrange' '
 	rm -f numbers.log &&
-	test_expect_code 1 git test range c1..c6 &&
+	test_expect_code 1 git-test range c1..c6 &&
 	printf "default %s${LF}" 2 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): retest known-bad with --retest' '
 	rm -f numbers.log &&
-	test_expect_code 1 git test range --retest c1..c6 &&
+	test_expect_code 1 git-test range --retest c1..c6 &&
 	printf "default %s${LF}" 4 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): retest with --force' '
 	# Test a good commit past the failing one:
-	git test range c5..c6 &&
+	git-test range c5..c6 &&
 	rm -f numbers.log &&
-	test_expect_code 1 git test range --force c2..c6 &&
+	test_expect_code 1 git-test range --force c2..c6 &&
 	printf "default %s${LF}" 3 4 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c5^{tree} &&
@@ -133,7 +130,7 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 test_expect_success 'default (failing-4-7-8): test --keep-going' '
 	git update-ref -d refs/notes/tests/default &&
 	rm -f numbers.log &&
-	test_expect_code 1 git test range --keep-going c2..c9 &&
+	test_expect_code 1 git-test range --keep-going c2..c9 &&
 	printf "default %s${LF}" 3 4 5 6 7 8 9 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -151,16 +148,16 @@ test_expect_success 'default (failing-4-7-8): test --keep-going' '
 
 test_expect_success 'default (failing-4-7-8): retest disjoint commits with --keep-going' '
 	rm -f numbers.log &&
-	test_expect_code 1 git test range --retest --keep-going c2..c9 &&
+	test_expect_code 1 git-test range --retest --keep-going c2..c9 &&
 	printf "default %s${LF}" 4 7 8 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): test range' '
 	git update-ref -d refs/notes/tests/default &&
-	git test add "test-number --log=numbers.log --bad 3 7 --ret=42 5 --good \*" &&
+	git-test add "test-number --log=numbers.log --bad 3 7 --ret=42 5 --good \*" &&
 	rm -f numbers.log &&
-	test_expect_code 42 git test range c3..c6 &&
+	test_expect_code 42 git-test range c3..c6 &&
 	printf "default %s${LF}" 4 5 >expected &&
 	test_cmp expected numbers.log
 '
@@ -168,34 +165,34 @@ test_expect_success 'default (retcodes): test range' '
 test_expect_success 'default (retcodes): test range again' '
 	# We do not remember return codes (should we?):
 	rm -f numbers.log &&
-	test_expect_code 1 git test range c3..c6 &&
+	test_expect_code 1 git-test range c3..c6 &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (retcodes): retest range' '
 	rm -f numbers.log &&
-	test_expect_code 42 git test range --retest c3..c6 &&
+	test_expect_code 42 git-test range --retest c3..c6 &&
 	printf "default %s${LF}" 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): force test range' '
 	rm -f numbers.log &&
-	test_expect_code 42 git test range --force c3..c6 &&
+	test_expect_code 42 git-test range --force c3..c6 &&
 	printf "default %s${LF}" 4 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 	rm -f numbers.log &&
-	test_expect_code 42 git test range --force --keep-going c1..c6 &&
+	test_expect_code 42 git-test range --force --keep-going c1..c6 &&
 	printf "default %s${LF}" 2 3 4 5 6 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): keep-going: bad wins if last' '
 	rm -f numbers.log &&
-	test_expect_code 1 git test range --force --keep-going c1..c8 &&
+	test_expect_code 1 git-test range --force --keep-going c1..c8 &&
 	printf "default %s${LF}" 2 3 4 5 6 7 8 >expected &&
 	test_cmp expected numbers.log
 '

--- a/test/range.t
+++ b/test/range.t
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+test_description="Test basic features"
+
+. ./sharness.sh
+
+PATH="$(pwd)/../test-helpers:$(pwd)/../bin:$PATH"
+export PATH
+
+SQ="'"
+
+test_expect_success '"test range" emits a help message' '
+	test_expect_code 2 git-test range --force c2..c6 2>actual &&
+	grep -q "the ${SQ}range${SQ} subcommand has been renamed" actual
+'
+
+test_done

--- a/test/run.t
+++ b/test/run.t
@@ -230,6 +230,20 @@ test_expect_success 'default (failing-4-7-8): test failing HEAD' '
 	test_cmp bad-note actual-c4
 '
 
+test_expect_success 'default (failing-4-7-8): test failing explicit HEAD' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git checkout c4 &&
+	git symbolic-ref HEAD >expected-branch &&
+	test_expect_code 1 git-test run HEAD &&
+	git symbolic-ref HEAD >actual-branch &&
+	test_cmp expected-branch actual-branch &&
+	printf "default %s${LF}" 4 >expected &&
+	test_cmp expected numbers.log &&
+	git notes --ref=tests/default show $c4^{tree} >actual-c4 &&
+	test_cmp bad-note actual-c4
+'
+
 test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 	git update-ref -d refs/notes/tests/default &&
 	rm -f numbers.log &&

--- a/test/run.t
+++ b/test/run.t
@@ -27,7 +27,7 @@ test_expect_success 'Set up test repository' '
 test_expect_success 'default (passing): test range' '
 	git-test add "test-number --log=numbers.log --good \*" &&
 	rm -f numbers.log &&
-	git-test range c2..c6 &&
+	git-test run c2..c6 &&
 	printf "default %s${LF}" 3 4 5 6 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -40,34 +40,34 @@ test_expect_success 'default (passing): test range' '
 
 test_expect_success 'default (passing): do not re-test known-good commits' '
 	rm -f numbers.log &&
-	git-test range c3..c5 &&
+	git-test run c3..c5 &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (passing): do not re-test known-good subrange' '
 	rm -f numbers.log &&
-	git-test range c1..c7 &&
+	git-test run c1..c7 &&
 	printf "default %s${LF}" 2 7 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): do not retest known-good even with --retest' '
 	rm -f numbers.log &&
-	git-test range --retest c0..c8 &&
+	git-test run --retest c0..c8 &&
 	printf "default %s${LF}" 1 8 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): retest with --force' '
 	rm -f numbers.log &&
-	git-test range --force c5..c9 &&
+	git-test run --force c5..c9 &&
 	printf "default %s${LF}" 6 7 8 9 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): forget some results' '
 	rm -f numbers.log &&
-	git-test range --forget c4..c7 &&
+	git-test run --forget c4..c7 &&
 	test_must_fail test -f numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c5^{tree} &&
 	test_must_fail git notes --ref=tests/default show $c7^{tree}
@@ -75,7 +75,7 @@ test_expect_success 'default (passing): forget some results' '
 
 test_expect_success 'default (passing): retest forgotten commits' '
 	rm -f numbers.log &&
-	git-test range c3..c8 &&
+	git-test run c3..c8 &&
 	printf "default %s${LF}" 5 6 7 >expected &&
 	test_cmp expected numbers.log
 '
@@ -84,7 +84,7 @@ test_expect_success 'default (failing-4-7-8): test range' '
 	git update-ref -d refs/notes/tests/default &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 --good \*" &&
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range c2..c5 &&
+	test_expect_code 1 git-test run c2..c5 &&
 	printf "default %s${LF}" 3 4 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -97,29 +97,29 @@ test_expect_success 'default (failing-4-7-8): test range' '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known commits' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range c2..c5 &&
+	test_expect_code 1 git-test run c2..c5 &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known subrange' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range c1..c6 &&
+	test_expect_code 1 git-test run c1..c6 &&
 	printf "default %s${LF}" 2 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): retest known-bad with --retest' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range --retest c1..c6 &&
+	test_expect_code 1 git-test run --retest c1..c6 &&
 	printf "default %s${LF}" 4 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): retest with --force' '
 	# Test a good commit past the failing one:
-	git-test range c5..c6 &&
+	git-test run c5..c6 &&
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range --force c2..c6 &&
+	test_expect_code 1 git-test run --force c2..c6 &&
 	printf "default %s${LF}" 3 4 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c5^{tree} &&
@@ -130,7 +130,7 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 test_expect_success 'default (failing-4-7-8): test --keep-going' '
 	git update-ref -d refs/notes/tests/default &&
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range --keep-going c2..c9 &&
+	test_expect_code 1 git-test run --keep-going c2..c9 &&
 	printf "default %s${LF}" 3 4 5 6 7 8 9 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -148,7 +148,7 @@ test_expect_success 'default (failing-4-7-8): test --keep-going' '
 
 test_expect_success 'default (failing-4-7-8): retest disjoint commits with --keep-going' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range --retest --keep-going c2..c9 &&
+	test_expect_code 1 git-test run --retest --keep-going c2..c9 &&
 	printf "default %s${LF}" 4 7 8 >expected &&
 	test_cmp expected numbers.log
 '
@@ -157,7 +157,7 @@ test_expect_success 'default (retcodes): test range' '
 	git update-ref -d refs/notes/tests/default &&
 	git-test add "test-number --log=numbers.log --bad 3 7 --ret=42 5 --good \*" &&
 	rm -f numbers.log &&
-	test_expect_code 42 git-test range c3..c6 &&
+	test_expect_code 42 git-test run c3..c6 &&
 	printf "default %s${LF}" 4 5 >expected &&
 	test_cmp expected numbers.log
 '
@@ -165,34 +165,34 @@ test_expect_success 'default (retcodes): test range' '
 test_expect_success 'default (retcodes): test range again' '
 	# We do not remember return codes (should we?):
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range c3..c6 &&
+	test_expect_code 1 git-test run c3..c6 &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (retcodes): retest range' '
 	rm -f numbers.log &&
-	test_expect_code 42 git-test range --retest c3..c6 &&
+	test_expect_code 42 git-test run --retest c3..c6 &&
 	printf "default %s${LF}" 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): force test range' '
 	rm -f numbers.log &&
-	test_expect_code 42 git-test range --force c3..c6 &&
+	test_expect_code 42 git-test run --force c3..c6 &&
 	printf "default %s${LF}" 4 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 	rm -f numbers.log &&
-	test_expect_code 42 git-test range --force --keep-going c1..c6 &&
+	test_expect_code 42 git-test run --force --keep-going c1..c6 &&
 	printf "default %s${LF}" 2 3 4 5 6 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): keep-going: bad wins if last' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test range --force --keep-going c1..c8 &&
+	test_expect_code 1 git-test run --force --keep-going c1..c8 &&
 	printf "default %s${LF}" 2 3 4 5 6 7 8 >expected &&
 	test_cmp expected numbers.log
 '

--- a/test/run.t
+++ b/test/run.t
@@ -112,6 +112,23 @@ test_expect_success 'default (passing): commits uniqified' '
 	test_cmp expected numbers.log
 '
 
+test_expect_success 'default (passing): read commits from stdin' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git rev-list c2..c6 | git-test run --stdin &&
+	printf "default %s${LF}" 6 5 4 3 >expected &&
+	test_cmp expected numbers.log
+'
+
+test_expect_success 'default (passing): combine args and stdin' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git rev-list c2..c6 | git-test run --stdin c5 c8 &&
+	# Note that rev-list was called without --reverse:
+	printf "default %s${LF}" 5 8 6 4 3 >expected &&
+	test_cmp expected numbers.log
+'
+
 test_expect_success 'default (failing-4-7-8): test range' '
 	git update-ref -d refs/notes/tests/default &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 --good \*" &&

--- a/test/run.t
+++ b/test/run.t
@@ -80,6 +80,30 @@ test_expect_success 'default (passing): retest forgotten commits' '
 	test_cmp expected numbers.log
 '
 
+test_expect_success 'default (passing): test a single commit' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git-test run c5 &&
+	printf "default %s${LF}" 5 >expected &&
+	test_cmp expected numbers.log
+'
+
+test_expect_success 'default (passing): test a few single commits' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git-test run c2 c6 c4 &&
+	printf "default %s${LF}" 2 6 4 >expected &&
+	test_cmp expected numbers.log
+'
+
+test_expect_success 'default (passing): test a single commit and a range' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git-test run c9 c4..c6 &&
+	printf "default %s${LF}" 9 5 6 >expected &&
+	test_cmp expected numbers.log
+'
+
 test_expect_success 'default (failing-4-7-8): test range' '
 	git update-ref -d refs/notes/tests/default &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 --good \*" &&

--- a/test/run.t
+++ b/test/run.t
@@ -104,6 +104,14 @@ test_expect_success 'default (passing): test a single commit and a range' '
 	test_cmp expected numbers.log
 '
 
+test_expect_success 'default (passing): commits uniqified' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git-test run c4..c6 c8 c5 c3..c9 &&
+	printf "default %s${LF}" 5 6 8 4 7 9 >expected &&
+	test_cmp expected numbers.log
+'
+
 test_expect_success 'default (failing-4-7-8): test range' '
 	git update-ref -d refs/notes/tests/default &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 --good \*" &&

--- a/test/run.t
+++ b/test/run.t
@@ -129,17 +129,6 @@ test_expect_success 'default (passing): combine args and stdin' '
 	test_cmp expected numbers.log
 '
 
-test_expect_success 'default (passing): test HEAD' '
-	git update-ref -d refs/notes/tests/default &&
-	rm -f numbers.log &&
-	git checkout c5 &&
-	git-test run &&
-	printf "default %s${LF}" 5 >expected &&
-	test_cmp expected numbers.log &&
-	git notes --ref=tests/default show $c5^{tree} >actual-c5 &&
-	test_cmp good-note actual-c5
-'
-
 test_expect_success 'default (failing-4-7-8): test range' '
 	git update-ref -d refs/notes/tests/default &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 666 --good \*" &&
@@ -213,28 +202,62 @@ test_expect_success 'default (failing-4-7-8): retest disjoint commits with --kee
 	test_cmp expected numbers.log
 '
 
+test_expect_success 'default (failing-4-7-8): test passing HEAD' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git checkout c2 &&
+	git symbolic-ref HEAD >expected-branch &&
+	git-test run &&
+	git symbolic-ref HEAD >actual-branch &&
+	test_cmp expected-branch actual-branch &&
+	printf "default %s${LF}" 2 >expected &&
+	test_cmp expected numbers.log &&
+	git notes --ref=tests/default show $c2^{tree} >actual-c2 &&
+	test_cmp good-note actual-c2
+'
+
+test_expect_success 'default (failing-4-7-8): test failing HEAD' '
+	git update-ref -d refs/notes/tests/default &&
+	rm -f numbers.log &&
+	git checkout c4 &&
+	git symbolic-ref HEAD >expected-branch &&
+	test_expect_code 1 git-test run &&
+	git symbolic-ref HEAD >actual-branch &&
+	test_cmp expected-branch actual-branch &&
+	printf "default %s${LF}" 4 >expected &&
+	test_cmp expected numbers.log &&
+	git notes --ref=tests/default show $c4^{tree} >actual-c4 &&
+	test_cmp bad-note actual-c4
+'
+
 test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 	git update-ref -d refs/notes/tests/default &&
 	rm -f numbers.log &&
-	git checkout c5 &&
+	git checkout c4 &&
+	git symbolic-ref HEAD >expected-branch &&
 	echo 42 >number &&
 	test_when_finished "git reset --hard HEAD" &&
 	git-test run &&
+	git symbolic-ref HEAD >actual-branch &&
+	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 42 >expected &&
 	test_cmp expected numbers.log &&
-	test_must_fail git notes --ref=tests/default show $c5^{tree}
+	test_must_fail git notes --ref=tests/default show $c4^{tree}
 '
 
 test_expect_success 'default (failing-4-7-8): test failing dirty working copy' '
 	git update-ref -d refs/notes/tests/default &&
 	rm -f numbers.log &&
-	git checkout c5 &&
+	git checkout c2 &&
+	git symbolic-ref HEAD >expected-branch &&
 	echo 666 >number &&
 	test_when_finished "git reset --hard HEAD" &&
 	test_expect_code 1 git-test run &&
+	git symbolic-ref HEAD >actual-branch &&
+	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 666 >expected &&
 	test_cmp expected numbers.log &&
-	test_must_fail git notes --ref=tests/default show $c5^{tree}
+	test_must_fail git notes --ref=tests/default show $c2^{tree}
 '
 
 test_expect_success 'default (retcodes): test range' '

--- a/test/sharness.d/env.sh
+++ b/test/sharness.d/env.sh
@@ -1,0 +1,5 @@
+PATH="$(pwd)/test-helpers:$(pwd)/../bin:$PATH"
+export PATH
+
+SQ="'"
+DQ='"'

--- a/test/test-number.t
+++ b/test/test-number.t
@@ -4,9 +4,6 @@ test_description="Test the test-number helper script"
 
 . ./sharness.sh
 
-PATH="$(pwd)/../test-helpers:$(pwd)/../bin:$PATH"
-export PATH
-
 test_expect_success 'Test good' '
 	echo "4" >number &&
 	test-number 4 &&


### PR DESCRIPTION
* Allow multiple arguments.
* If an argument is in the form `A..B`, treat it as a range; otherwise, treat it as a single commit.
* Add a `--stdin` option to read commits to test from standard input.
* If no commits are specified on the command line, and `--stdin` is not specified, then
    * If the working tree is clean, then test `HEAD` (avoiding any checkouts).
    * If the working tree is dirty, then test the contents of the working tree (without recording the test results in notes).

Because of the new semantics, the old subcommand name, `range`, doesn't make sense anymore. So rename it to `run`. Add a stub `range` subcommand that just points the user to the new `run` subcommand.

Fixes #2.

/cc @peff, with whom some of these changes were discussed.
