### PR TITLE
Allow tests and their results to be forgotten

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,23 @@ You can define multiple tests in a single repository (e.g., cheap vs. expensive 
 
 ### Retrying tests and/or forgetting old test results
 
-If you have flaky tests that occasionally fail for bogus reasons, you might want to re-run the test against a commit even though `git test` has already recorded a result for that commit. To do so, run `git test run` with the `--force`/`-f` or `--retest` options. If you want to forget old test results without retesting (e.g., if you change the test command), use `--forget`.
+If you have flaky tests that occasionally fail for bogus reasons, you might want to re-run the test against a commit even though `git test` has already recorded a result for that commit. To do so, run `git test run` with the `--force`/`-f` or `--retest` options.
+
+If you want to forget particular old test results without retesting, run `git test run` with the `--forget` option.
+
+If you want to permanently forget *all* stored results for a particular test (e.g., if something in your environment has changed), run
+
+    git test forget-results [--test=<name>]
 
 ### Continue on test failures
 
 Normally, `git test run` stops at the first broken commit that it finds. If you'd prefer for it to continue, use the `--keep-going`/`-k` option.
+
+### Removing tests
+
+To permanently remove a test definition and all of its stored results, run
+
+    git test remove [--test=<name>]
 
 ### For help
 
@@ -112,8 +124,6 @@ Some other features that would be nice:
 *   Be more consistent about restoring `HEAD`. `git test run` currently checks out the branch that you started on when it is finished, but only if all of the tests passed. We need some kind of `git test reset` command analogous to `git bisect reset`.
 
 *   `git test bisect`: run `git bisect run` against a range of commits, using a configured test as the command that `bisect` uses to decide whether a commit is good/bad.
-
-*   `git test remove`: remove a test definition and its associated notes.
 
 *   `git test prune`: delete notes for obsolete trees.
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -163,6 +163,10 @@ def check_git_output(*popenargs, **kwargs):
     return _decode_output(check_output(*popenargs, **kwargs))
 
 
+class RevParseError(Fatal):
+    pass
+
+
 def rev_parse(arg, abbrev=None):
     if abbrev:
         cmd = ['git', 'rev-parse', '--verify', '-q', '--short=%d' % (abbrev,), arg]
@@ -172,7 +176,7 @@ def rev_parse(arg, abbrev=None):
     try:
         return check_git_output(cmd).strip()
     except CalledProcessError:
-        raise Fatal('%r is not a valid commit!' % (arg,))
+        raise RevParseError('%r is not a valid commit!' % (arg,))
 
 
 def rev_list(*args):

--- a/bin/git-test
+++ b/bin/git-test
@@ -411,6 +411,13 @@ def initialize_notes(name, msg):
     check_call(cmd)
 
 
+def remove_notes(name, msg):
+    """Delete the note reference for the test named `name`."""
+
+    cmd = ['git', 'update-ref', '-d', 'refs/notes/tests/%s' % (name,), '-m', msg]
+    check_call(cmd)
+
+
 REUSE_RESULTS_WARNING = """\
 WARNING: there are already results stored for the test named '%(name)s'.
 Those results will be considered valid for the new test. If that is
@@ -592,6 +599,30 @@ def cmd_run(parser, options):
         return
 
 
+def cmd_forget_results(parser, options):
+    cmd = ['git', 'config', 'test.%s.command' % (options.test,)]
+    try:
+        check_call(cmd, stdout=open(os.devnull, 'wb'))
+        test_defined = True
+    except CalledProcessError:
+        # There is no test defined; simply delete the notes reference:
+        remove_notes(
+            options.test, 'Test results deleted by \'git test forget-results\''
+            )
+    else:
+        initialize_notes(
+            options.test, 'Test results reinitialized by \'git test forget-results\''
+            )
+
+
+def cmd_remove(parser, options):
+    cmd = ['git', 'config', '--remove-section', 'test.%s' % (options.test,)]
+    check_call(cmd)
+    remove_notes(
+        options.test, 'Test results deleted by \'git test remove\''
+        )
+
+
 def cmd_help(parser, options, subparsers):
     if options.cmd is not None:
         try:
@@ -625,7 +656,7 @@ def main(args):
     subparser.add_argument(
         '--test', '-t', metavar='name',
         action='store', default='default',
-        help='name of test to add',
+        help='name of test to add (default is \'default\')',
         )
     subparser.add_argument(
         '--forget',
@@ -646,7 +677,7 @@ def main(args):
         subparser.add_argument(
             '--test', '-t', metavar='name',
             action='store', default='default',
-            help='name of test',
+            help='name of test (default is \'default\')',
             )
         subparser.add_argument(
             '--force', '-f', action='store_true',
@@ -706,6 +737,32 @@ def main(args):
     add_run_arguments(subparser)
 
     subparser = subparsers.add_parser(
+        'forget-results',
+        description=(
+            'Forget all stored test results for a test.'
+            ),
+        help='permanently forget stored results for a test',
+        )
+    subparser.add_argument(
+        '--test', '-t', metavar='name',
+        action='store', default='default',
+        help='name of test whose results should be forgotten (default is \'default\')',
+        )
+
+    subparser = subparsers.add_parser(
+        'remove',
+        description=(
+            'Remove a test definition and all of its stored results.'
+            ),
+        help='remove a test definition and all of its stored results',
+        )
+    subparser.add_argument(
+        '--test', '-t', metavar='name',
+        action='store', default='default',
+        help='name of test to remove (default is \'default\')',
+        )
+
+    subparser = subparsers.add_parser(
         'help',
         description=(
             'Print out help for "git test" in general or for a specific '
@@ -726,6 +783,10 @@ def main(args):
         cmd_run(parser, options)
     elif options.subcommand == 'range':
         parser.error('the \'range\' subcommand has been renamed to \'run\'.')
+    elif options.subcommand == 'forget-results':
+        cmd_forget_results(parser, options)
+    elif options.subcommand == 'remove':
+        cmd_remove(parser, options)
     elif options.subcommand == 'help':
         cmd_help(parser, options, subparsers)
     else:

--- a/bin/git-test
+++ b/bin/git-test
@@ -199,6 +199,22 @@ def rev_list(*args):
         raise Fatal('git rev-list %s failed' % (' '.join(args),))
 
 
+_empty_tree = None
+
+def get_empty_tree():
+    """Return the SHA-1 for the empty tree object.
+
+    Also make sure it is present in the current repository."""
+
+    global _empty_tree
+
+    if _empty_tree is None:
+        cmd = ['git', 'hash-object', '-t', 'tree', '-w', '--stdin']
+        _empty_tree = check_output(cmd, stdin=open(os.devnull, 'rb')).rstrip()
+
+    return _empty_tree
+
+
 def refresh_index():
     process = subprocess.Popen(
         ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
@@ -383,9 +399,49 @@ def setup_test(name):
     sys.stdout.write('Using test %s; command: %s\n' % (name, command))
 
 
+def initialize_notes(name, msg):
+    cmd = ['git', 'commit-tree', '-m', msg, get_empty_tree()]
+    commit = check_output(cmd).rstrip()
+
+    cmd = [
+        'git', 'update-ref',
+        '-m', 'test: %s' % (msg,),
+        'refs/notes/tests/%s' % (name,), commit,
+        ]
+    check_call(cmd)
+
+
+REUSE_RESULTS_WARNING = """\
+WARNING: there are already results stored for the test named '%(name)s'.
+Those results will be considered valid for the new test. If that is
+not what you want, please re-run this command with the '--forget' option.
+"""
+
+
 def cmd_add(parser, options):
     cmd = ['git', 'config', 'test.%s.command' % (options.test,), options.command]
     check_call(cmd)
+
+    if options.forget:
+        initialize = True
+    else:
+        try:
+            old_tree = rev_parse('refs/notes/tests/%s^{tree}' % (options.test,))
+        except RevParseError:
+            initialize = True
+        else:
+            # The notes reference already exists and we weren't asked
+            # to `--forget`, so leave the existing notes in place:
+            initialize = False
+            if old_tree != get_empty_tree() and options.forget != False:
+                # The notes reference already exists and contains
+                # results and the user didn't explicitly ask for
+                # `--keep`; emit a warning in case the user forgot to
+                # `--forget`:
+                sys.stderr.write(REUSE_RESULTS_WARNING % dict(name=options.test))
+
+    if initialize:
+        initialize_notes(options.test, 'Test results initialized by \'git test add\'')
 
 
 def uniqify(l):
@@ -570,6 +626,16 @@ def main(args):
         '--test', '-t', metavar='name',
         action='store', default='default',
         help='name of test to add',
+        )
+    subparser.add_argument(
+        '--forget',
+        action='store_true', default=None,
+        help='forget any existing results',
+        )
+    subparser.add_argument(
+        '--keep',
+        action='store_false', dest='forget',
+        help='keep any existing results (default)',
         )
     subparser.add_argument(
         'command',

--- a/bin/git-test
+++ b/bin/git-test
@@ -58,6 +58,7 @@ It will only test commits with trees that it hasn't been seen before.
 
 import locale
 import sys
+import os
 import re
 import subprocess
 import argparse
@@ -267,7 +268,7 @@ def read_status(r, rs):
 
     cmd = ['git', 'notes', '--ref=%s' % (notes_ref,), 'show', '%s^{tree}' % (r,)]
     try:
-        status = check_output(cmd, stderr=open('/dev/null', 'wb')).rstrip()
+        status = check_output(cmd, stderr=open(os.devnull, 'wb')).rstrip()
     except CalledProcessError:
         return 'unknown'
 
@@ -457,7 +458,7 @@ def cmd_run(parser, options):
 
     try:
         cmd = ['git', 'symbolic-ref', 'HEAD']
-        head = check_output(cmd, stderr=open('/dev/null', 'wb')).rstrip()
+        head = check_output(cmd, stderr=open(os.devnull, 'wb')).rstrip()
     except CalledProcessError:
         cmd = ['git', 'rev-parse', 'HEAD']
         head = check_output(cmd).rstrip()

--- a/test/add.t
+++ b/test/add.t
@@ -5,21 +5,58 @@ test_description="Test adding and changing test definitions"
 . ./sharness.sh
 
 test_expect_success 'Set up test repository' '
-	git init .
+	git init . &&
+	git config user.name "Test User" &&
+	git config user.email "user@example.com" &&
+	git commit --allow-empty -m 'Initial' &&
+	echo 4b825dc642cb6eb9a060e54bf8d69288fbee4904 >empty_tree
 '
 
 test_expect_success 'Configure a default test' '
-	git-test add "echo foo" &&
+	git-test add "echo foo" 2>warning &&
+	test_must_fail grep -q "there are already results" warning &&
 	echo "echo foo" >expected &&
+	git config --get test.default.command >actual &&
+	test_cmp expected actual &&
+	git rev-parse --verify --quiet refs/notes/tests/default^{tree} >tree &&
+	test_cmp empty_tree tree
+'
+
+test_expect_success 'Change the default test' '
+	git-test add "echo bar" 2>warning &&
+	test_must_fail grep -q "there are already results" warning &&
+	echo "echo bar" >expected &&
 	git config --get test.default.command >actual &&
 	test_cmp expected actual
 '
 
-test_expect_success 'Change the default test' '
-	git-test add "echo bar" &&
-	echo "echo bar" >expected &&
+test_expect_success 'Warn about old results but keep them' '
+	# Add some simulated test results:
+	git notes --ref=tests/default add -m 'good' HEAD^{tree} &&
+	git-test add "echo foobar" 2>warning &&
+	grep -q "there are already results" warning &&
+	echo "echo foobar" >expected &&
 	git config --get test.default.command >actual &&
-	test_cmp expected actual
+	test_cmp expected actual &&
+	git notes --ref=tests/default show HEAD^{tree}
+'
+
+test_expect_success 'With --keep, silently keep old results' '
+	git-test add --keep "echo keep" 2>warning &&
+	test_must_fail grep -q "there are already results" warning &&
+	echo "echo keep" >expected &&
+	git config --get test.default.command >actual &&
+	test_cmp expected actual &&
+	git notes --ref=tests/default show HEAD^{tree}
+'
+
+test_expect_success 'Forget old results' '
+	git-test add --forget "echo forget" 2>warning &&
+	test_must_fail grep -q "there are already results" warning &&
+	echo "echo forget" >expected &&
+	git config --get test.default.command >actual &&
+	test_cmp expected actual &&
+	test_must_fail git notes --ref=tests/default show HEAD^{tree}
 '
 
 test_expect_success 'Configure a different test' '

--- a/test/run-directly.t
+++ b/test/run-directly.t
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+test_description="Verify that tests don't run 'git-test' via git"
+
+. ./sharness.sh
+
+SP=' '
+
+test_expect_success 'forget-results' '
+	test_must_fail grep "git${SP}test" "$TEST_DIR"/*.t
+'
+
+test_done

--- a/test/run.t
+++ b/test/run.t
@@ -81,7 +81,7 @@ test_expect_success 'default (passing): retest forgotten commits' '
 '
 
 test_expect_success 'default (passing): test a single commit' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git-test run c5 &&
 	printf "default %s${LF}" 5 >expected &&
@@ -89,7 +89,7 @@ test_expect_success 'default (passing): test a single commit' '
 '
 
 test_expect_success 'default (passing): test a few single commits' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git-test run c2 c6 c4 &&
 	printf "default %s${LF}" 2 6 4 >expected &&
@@ -97,7 +97,7 @@ test_expect_success 'default (passing): test a few single commits' '
 '
 
 test_expect_success 'default (passing): test a single commit and a range' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git-test run c9 c4..c6 &&
 	printf "default %s${LF}" 9 5 6 >expected &&
@@ -105,7 +105,7 @@ test_expect_success 'default (passing): test a single commit and a range' '
 '
 
 test_expect_success 'default (passing): commits uniqified' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git-test run c4..c6 c8 c5 c3..c9 &&
 	printf "default %s${LF}" 5 6 8 4 7 9 >expected &&
@@ -113,7 +113,7 @@ test_expect_success 'default (passing): commits uniqified' '
 '
 
 test_expect_success 'default (passing): read commits from stdin' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git rev-list c2..c6 | git-test run --stdin &&
 	printf "default %s${LF}" 6 5 4 3 >expected &&
@@ -121,7 +121,7 @@ test_expect_success 'default (passing): read commits from stdin' '
 '
 
 test_expect_success 'default (passing): combine args and stdin' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git rev-list c2..c6 | git-test run --stdin c5 c8 &&
 	# Note that rev-list was called without --reverse:
@@ -130,7 +130,7 @@ test_expect_success 'default (passing): combine args and stdin' '
 '
 
 test_expect_success 'default (failing-4-7-8): test range' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 666 --good \*" &&
 	rm -f numbers.log &&
 	test_expect_code 1 git-test run c2..c5 &&
@@ -177,7 +177,7 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 '
 
 test_expect_success 'default (failing-4-7-8): test --keep-going' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	test_expect_code 1 git-test run --keep-going c2..c9 &&
 	printf "default %s${LF}" 3 4 5 6 7 8 9 >expected &&
@@ -203,7 +203,7 @@ test_expect_success 'default (failing-4-7-8): retest disjoint commits with --kee
 '
 
 test_expect_success 'default (failing-4-7-8): test passing HEAD' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git checkout c2 &&
 	git symbolic-ref HEAD >expected-branch &&
@@ -217,7 +217,7 @@ test_expect_success 'default (failing-4-7-8): test passing HEAD' '
 '
 
 test_expect_success 'default (failing-4-7-8): test failing HEAD' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
@@ -231,7 +231,7 @@ test_expect_success 'default (failing-4-7-8): test failing HEAD' '
 '
 
 test_expect_success 'default (failing-4-7-8): test failing explicit HEAD' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
@@ -245,7 +245,7 @@ test_expect_success 'default (failing-4-7-8): test failing explicit HEAD' '
 '
 
 test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
@@ -260,7 +260,7 @@ test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 '
 
 test_expect_success 'default (failing-4-7-8): test failing dirty working copy' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	rm -f numbers.log &&
 	git checkout c2 &&
 	git symbolic-ref HEAD >expected-branch &&
@@ -275,7 +275,7 @@ test_expect_success 'default (failing-4-7-8): test failing dirty working copy' '
 '
 
 test_expect_success 'default (retcodes): test range' '
-	git update-ref -d refs/notes/tests/default &&
+	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 3 7 --ret=42 5 --good \*" &&
 	rm -f numbers.log &&
 	test_expect_code 42 git-test run c3..c6 &&

--- a/test/sharness.d/env.sh
+++ b/test/sharness.d/env.sh
@@ -1,4 +1,7 @@
-PATH="$(pwd)/test-helpers:$(pwd)/../bin:$PATH"
+TEST_DIR="$(pwd)"
+BASE_DIR="$TEST_DIR/.."
+
+PATH="$TEST_DIR/test-helpers:$BASE_DIR/bin:$PATH"
 export PATH
 
 SQ="'"


### PR DESCRIPTION
* Add a new subcommand `git test remove [--test=<name>]` to remove a test and its results.
* Add a new subcommand `git test forget-results [--test=<name>]` to forget a test's results but retain the test definition.
* Add new options `--forget` and `--keep` to `git test add`, to cause existing test results to be forgotten or kept. If neither option is specified and stored results exist, emit a warning.
