### PR TITLE
Make the standard output of `git test` usable, and add subcommand `git test results`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ or test an arbitrary set of commits supplied via standard input:
 
     git rev-list feature1 feature2 ^master | git test run --stdin
 
+You can adjust the verbosity of the output using the `--verbosity`/`-v` or `--quiet`/`-q` options. Both of these options can be specified multiple times.
+
 ### Define multiple tests
 
 You can define multiple tests in a single repository (e.g., cheap vs. expensive tests). Their results are kept separate. By default, the test called `default` is run, but you can specify a different test to add/run using the `--test=<name>`/`-t <name>` option:

--- a/bin/git-test
+++ b/bin/git-test
@@ -168,6 +168,38 @@ def check_output(*popenargs, **kwargs):
         raise CalledProcessError(e.returncode, e.cmd, _decode_output(e.output))
 
 
+def chatty_call(*popenargs, **kwargs):
+    """Run a program like `check_call()`, but with variable verbosity.
+
+    Compare the current global `verbosity` with the keyword argument `level`:
+
+    * If verbosity < level - 1, then never show the command's output.
+    * If verbosity == level - 1, then show the output only if there is an error.
+    * If verbosity >= level, then show the output in any case.
+
+    The default level is 1 (i.e., at the default verbosity level, show
+    the output only in the case of an error).
+
+    The caller should not set keyword arguments `stdout` or `stderr`.
+
+    """
+
+    level = kwargs.pop('level', 1)
+    kwargs['stderr'] = subprocess.STDOUT
+    if verbosity < level - 1:
+        kwargs['stdout'] = open(os.devnull, 'wb')
+        check_call(*popenargs, **kwargs)
+    elif verbosity == level - 1:
+        try:
+            check_output(*popenargs, **kwargs)
+        except CalledProcessError as e:
+            sys.stderr.write(e.output)
+            raise
+    else:
+        kwargs['stdout'] = sys.stderr
+        check_call(*popenargs, **kwargs)
+
+
 class RevParseError(Fatal):
     pass
 
@@ -235,7 +267,7 @@ def unstaged_changes():
     """Return True iff there are unstaged changes in the working copy"""
 
     try:
-        check_call(['git', 'diff-files', '--quiet', '--ignore-submodules'])
+        chatty_call(['git', 'diff-files', '--quiet', '--ignore-submodules'])
         return False
     except CalledProcessError:
         return True
@@ -245,7 +277,7 @@ def uncommitted_changes():
     """Return True iff the index contains uncommitted changes."""
 
     try:
-        check_call([
+        chatty_call([
             'git', 'diff-index', '--cached', '--quiet',
             '--ignore-submodules', 'HEAD', '--',
             ])
@@ -314,7 +346,7 @@ class Test(object):
             '-m', 'test: %s' % (msg,),
             self.full_ref, commit,
             ]
-        check_call(cmd)
+        chatty_call(cmd)
 
     def read_status(self, revision, revision_short):
         cmd = [
@@ -340,11 +372,12 @@ class Test(object):
             'add', '-f', '%s^{tree}' % (revision,), '-m', value,
             ]
         try:
-            check_call(cmd)
+            chatty_call(cmd)
         except CalledProcessError:
             raise Fatal('fatal: error adding note to %s^{tree}' % (revision,))
         else:
-            sys.stderr.write('Marked tree %s^{tree} to be %s\n' % (revision, value))
+            if verbosity >= 0:
+                sys.stderr.write('Marked tree %s^{tree} to be %s\n' % (revision, value))
 
     def forget_status(self, revisions):
         """Forget the stored results (if any) for the specified revisions."""
@@ -354,11 +387,21 @@ class Test(object):
             'remove', '--ignore-missing', '--stdin',
             ]
 
+        level = 1
+        kwargs = dict(stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        if verbosity < level - 1:
+            kwargs['stdout'] = open(os.devnull, 'wb')
+        elif verbosity == level - 1:
+            kwargs['stdout'] = subprocess.PIPE
+
         try:
-            process = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-            communicate(process, ''.join('%s^{tree}\n' % (r,) for r in revisions))
+            process = subprocess.Popen(cmd, **kwargs)
+            out, err = communicate(process, ''.join('%s^{tree}\n' % (r,) for r in revisions))
             retcode = process.poll()
             if retcode:
+                if verbosity == level - 1:
+                    sys.stderr.write(out)
                 raise Fatal('fatal: error removing one or more existing notes')
         except CalledProcessError:
             raise Fatal('fatal: error removing one or more existing notes')
@@ -376,7 +419,7 @@ class Test(object):
     @command.setter
     def command(self, value):
         cmd = ['git', 'config', 'test.%s.command' % (self.name,), value]
-        check_call(cmd)
+        chatty_call(cmd)
         self._command = value
 
     def run(self):
@@ -384,7 +427,7 @@ class Test(object):
 
         cmd = ['sh', '-c', self.command]
         try:
-            check_call(cmd, stdout=sys.stderr)
+            chatty_call(cmd, level=0)
         except CalledProcessError as e:
             raise UserTestError(e.returncode, e.cmd, e.output)
 
@@ -392,12 +435,13 @@ class Test(object):
         try:
             self.run()
         except UserTestError as e:
-            cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
             sys.stdout.write('%s^{tree} bad\n' % (revision,))
-            sys.stderr.write(FAIL_HEADER_TEMPLATE % dict(revision=revision))
-            check_call(cmd, stdout=sys.stderr)
-            sys.stderr.write(FAIL_TRAILER_TEMPLATE % dict())
-            self.write_status(revision, 'bad')
+            if verbosity >= -1:
+                sys.stderr.write(FAIL_HEADER_TEMPLATE % dict(revision=revision))
+                cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
+                chatty_call(cmd, level=-1)
+                sys.stderr.write(FAIL_TRAILER_TEMPLATE % dict())
+                self.write_status(revision, 'bad')
             raise
         else:
             sys.stdout.write('%s^{tree} good\n' % (revision,))
@@ -410,26 +454,31 @@ class Test(object):
             'git', 'update-ref', '-d', 'refs/notes/tests/%s' % (self.name,),
             '-m', msg,
             ]
-        check_call(cmd)
+        chatty_call(cmd)
 
     def remove(self, msg):
         cmd = ['git', 'config', '--remove-section', 'test.%s' % (self.name,)]
-        check_call(cmd)
+        chatty_call(cmd)
         self.remove_status(msg)
 
 
 def prepare_revision(r):
-    cmd = ['git', 'checkout', r]
     try:
-        check_output(cmd, stderr=subprocess.STDOUT)
+        cmd = ['git', 'checkout', r]
+        chatty_call(cmd)
     except CalledProcessError as e:
         raise Fatal('fatal: error checking out commit %s:\n%s' % (r, e.output,))
 
-    cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
-    try:
-        check_call(cmd, stdout=sys.stderr)
-    except CalledProcessError as e:
-        raise Fatal('fatal: error displaying log for commit %s' % (r,))
+    if verbosity >= -1:
+        cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
+        try:
+            if verbosity >= 0:
+                sys.stderr.write('\n')
+            chatty_call(cmd, level=0)
+            if verbosity >= 0:
+                sys.stderr.write('\n')
+        except CalledProcessError as e:
+            raise Fatal('fatal: error displaying log for commit %s' % (r,))
 
 
 REUSE_RESULTS_WARNING = """\
@@ -481,7 +530,8 @@ def uniqify(l):
 def cmd_run(parser, options):
     test = Test(options.test)
 
-    sys.stderr.write('Using test %s; command: %s\n' % (test.name, test.command))
+    if verbosity >= 0:
+        sys.stderr.write('Using test %s; command: %s\n' % (test.name, test.command))
 
     try:
         require_clean_work_tree('test-run')
@@ -495,11 +545,13 @@ def cmd_run(parser, options):
             test.run()
         except UserTestError as e:
             sys.stdout.write('working-tree bad\n')
-            sys.stderr.write('\n!!! TEST FAILED !!!\n')
+            if verbosity >= -1:
+                sys.stderr.write('\n!!! TEST FAILED !!!\n')
             sys.exit(e.returncode)
         else:
             sys.stdout.write('working-tree good\n')
-            sys.stderr.write('\nTEST SUCCESSFUL\n')
+            if verbosity >= -1:
+                sys.stderr.write('\nTEST SUCCESSFUL\n')
         finally:
             sys.stderr.write(
                 'Note: working tree is dirty; results will not be saved.\n'
@@ -608,28 +660,33 @@ def cmd_run(parser, options):
 
     if not testing_head:
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
-        check_call(cmd, stdout=sys.stderr)
+        chatty_call(cmd)
 
-    sys.stderr.write('\n')
     if fail_count > 0:
-        if fail_count == 1:
-            sys.stderr.write('!!! %s TEST FAILED !!!\n' % (fail_count,))
-        else:
-            sys.stderr.write('!!! %s TESTS FAILED !!!\n' % (fail_count,))
+        if verbosity >= -1:
+            sys.stderr.write('\n')
+            if fail_count == 1:
+                sys.stderr.write('!!! %s TEST FAILED !!!\n' % (fail_count,))
+            else:
+                sys.stderr.write('!!! %s TESTS FAILED !!!\n' % (fail_count,))
 
         if last_failure is not None:
             sys.exit(last_failure)
         else:
             sys.exit(1)
     elif unknown_count > 0:
-        if unknown_count == 1:
-            sys.stderr.write('%s TEST UNKNOWN\n' % (unknown_count,))
-        else:
-            sys.stderr.write('%s TESTS UNKNOWN\n' % (unknown_count,))
+        if verbosity >= -1:
+            sys.stderr.write('\n')
+            if unknown_count == 1:
+                sys.stderr.write('%s TEST UNKNOWN\n' % (unknown_count,))
+            else:
+                sys.stderr.write('%s TESTS UNKNOWN\n' % (unknown_count,))
 
         sys.exit(2)
     else:
-        sys.stderr.write('ALL TESTS SUCCESSFUL\n')
+        if verbosity >= -1:
+            sys.stderr.write('\n')
+            sys.stderr.write('ALL TESTS SUCCESSFUL\n')
         return
 
 
@@ -638,7 +695,7 @@ def cmd_forget_results(parser, options):
 
     cmd = ['git', 'config', 'test.%s.command' % (test.name,)]
     try:
-        check_call(cmd, stdout=open(os.devnull, 'wb'))
+        chatty_call(cmd)
         test_defined = True
     except CalledProcessError:
         # There is no test defined; simply delete the notes reference:
@@ -845,6 +902,10 @@ def main(args):
     options = parser.parse_args(args)
 
     verbosity = options.verbose - options.quiet
+
+    # Expose the verbosity to child processes, in case they want to
+    # adjust their output levels, too:
+    os.environ['GIT_TEST_VERBOSITY'] = str(verbosity)
 
     if options.subcommand == 'add':
         cmd_add(parser, options)

--- a/bin/git-test
+++ b/bin/git-test
@@ -88,10 +88,10 @@ except ImportError:
             return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
 
 try:
-    from subprocess import check_output
+    from subprocess import check_output as _check_output
 except ImportError:
     # Use definition from Python 2.7 subprocess module:
-    def check_output(*popenargs, **kwargs):
+    def _check_output(*popenargs, **kwargs):
         if 'stdout' in kwargs:
             raise ValueError('stdout argument not allowed, it will be overridden.')
         process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
@@ -159,8 +159,11 @@ def _decode_output(value):
     return value.decode(sys.getfilesystemencoding(), 'surrogateescape')
 
 
-def check_git_output(*popenargs, **kwargs):
-    return _decode_output(check_output(*popenargs, **kwargs))
+def check_output(*popenargs, **kwargs):
+    try:
+        return _decode_output(_check_output(*popenargs, **kwargs))
+    except CalledProcessError as e:
+        raise CalledProcessError(e.returncode, e.cmd, _decode_output(e.output))
 
 
 class RevParseError(Fatal):
@@ -174,7 +177,7 @@ def rev_parse(arg, abbrev=None):
         cmd = ['git', 'rev-parse', '--verify', '-q', arg]
 
     try:
-        return check_git_output(cmd).strip()
+        return check_output(cmd).strip()
     except CalledProcessError:
         raise RevParseError('%r is not a valid commit!' % (arg,))
 
@@ -351,7 +354,7 @@ class Test(object):
 
         try:
             process = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-            process.communicate(''.join('%s^{tree}\n' % (r,) for r in revisions))
+            communicate(process, ''.join('%s^{tree}\n' % (r,) for r in revisions))
             retcode = process.poll()
             if retcode:
                 raise Fatal('fatal: error removing one or more existing notes')

--- a/bin/git-test
+++ b/bin/git-test
@@ -483,7 +483,7 @@ def cmd_run(parser, options):
     except UncleanWorkTreeError:
         # Unclean work tree; the only action allowed in this state is
         # testing the working copy:
-        if options.commits or options.stdin or options.forget:
+        if options.commits or options.stdin or options.forget or options.dry_run:
             raise
 
         try:
@@ -552,6 +552,7 @@ def cmd_run(parser, options):
 
     last_failure = None
     fail_count = 0
+    unknown_count = 0
 
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
@@ -563,7 +564,7 @@ def cmd_run(parser, options):
             sys.stderr.write('Tree %s^{tree} is already known to be good.\n' % (rs,))
 
         elif status == 'bad':
-            if options.retest:
+            if options.retest and not options.dry_run:
                 sys.stderr.write(
                     'Tree %s^{tree} was previously tested to be bad; retesting...\n'
                     % (rs,)
@@ -580,7 +581,11 @@ def cmd_run(parser, options):
                     sys.exit(1)
 
         elif status == 'unknown':
-            status = None
+            if options.dry_run:
+                sys.stdout.write('%s^{tree} unknown\n' % (r,))
+                unknown_count += 1
+            else:
+                status = None
 
         if status is None:
             if not testing_head:
@@ -611,6 +616,13 @@ def cmd_run(parser, options):
             sys.exit(last_failure)
         else:
             sys.exit(1)
+    elif unknown_count > 0:
+        if unknown_count == 1:
+            sys.stderr.write('%s TEST UNKNOWN\n' % (unknown_count,))
+        else:
+            sys.stderr.write('%s TESTS UNKNOWN\n' % (unknown_count,))
+
+        sys.exit(2)
     else:
         sys.stderr.write('ALL TESTS SUCCESSFUL\n')
         return
@@ -714,6 +726,12 @@ def main(args):
             help=(
                 'if a commit fails the test, continue testing other commits '
                 'rather than aborting'
+                ),
+            )
+        subparser.add_argument(
+            '--dry-run', '-n', action='store_true',
+            help=(
+                'show known results, without running any new tests'
                 ),
             )
         subparser.add_argument(

--- a/bin/git-test
+++ b/bin/git-test
@@ -236,6 +236,18 @@ def rev_list(*args):
         raise Fatal('git rev-list %s failed' % (' '.join(args),))
 
 
+def uniqify(l):
+    """Iterate over the unique items in l, in the original order.
+
+    Yield an item only the first time it is seen."""
+
+    seen = set()
+    for i in l:
+        if i not in seen:
+            yield i
+            seen.add(i)
+
+
 _empty_tree = None
 
 def get_empty_tree():
@@ -513,18 +525,6 @@ def cmd_add(parser, options):
 
     if initialize:
         test.initialize_status('Test results initialized by \'git test add\'')
-
-
-def uniqify(l):
-    """Iterate over the unique items in l, in the original order.
-
-    Yield an item only the first time it is seen."""
-
-    seen = set()
-    for i in l:
-        if i not in seen:
-            yield i
-            seen.add(i)
 
 
 def cmd_run(parser, options):

--- a/bin/git-test
+++ b/bin/git-test
@@ -109,6 +109,8 @@ except ImportError:
         return output
 
 
+verbosity = 0
+
 class Fatal(Exception):
     """An exception that indicates a normal failure of the script.
 
@@ -667,10 +669,33 @@ def cmd_help(parser, options, subparsers):
 
 
 def main(args):
+    global verbosity
+
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         )
+
+    def add_verbosity_options(parser, help=False):
+        if help:
+            verbose_help = 'generate more verbose output (may be specified multiple times)'
+            quiet_help = 'generate less verbose output (may be specified multiple times)'
+        else:
+            verbose_help = quiet_help = argparse.SUPPRESS
+
+        parser.add_argument(
+            '--verbose', '-v',
+            action='count', default=0,
+            help=verbose_help,
+            )
+        parser.add_argument(
+            '--quiet', '-q',
+            action='count', default=0,
+            help=quiet_help,
+            )
+
+    add_verbosity_options(parser, help=True)
+
     subparsers = parser.add_subparsers(
         dest='subcommand', help='sub-command',
         parser_class=argparse.ArgumentParser,
@@ -702,6 +727,7 @@ def main(args):
         'command',
         help='command to run',
         )
+    add_verbosity_options(subparser)
 
     def add_run_arguments(subparser):
         subparser.add_argument(
@@ -760,6 +786,7 @@ def main(args):
         help='run a test against one or more commits',
         )
     add_run_arguments(subparser)
+    add_verbosity_options(subparser)
 
     # This command is no longer supported, but emit a help message if
     # it is requested:
@@ -771,6 +798,7 @@ def main(args):
     # argparse will emit an error about unrecognized arguments and
     # abort before we get a chance to emit our help message:
     add_run_arguments(subparser)
+    add_verbosity_options(subparser)
 
     subparser = subparsers.add_parser(
         'forget-results',
@@ -784,6 +812,7 @@ def main(args):
         action='store', default='default',
         help='name of test whose results should be forgotten (default is \'default\')',
         )
+    add_verbosity_options(subparser)
 
     subparser = subparsers.add_parser(
         'remove',
@@ -797,6 +826,7 @@ def main(args):
         action='store', default='default',
         help='name of test to remove (default is \'default\')',
         )
+    add_verbosity_options(subparser)
 
     subparser = subparsers.add_parser(
         'help',
@@ -810,8 +840,11 @@ def main(args):
         'cmd', nargs='?', default=None,
         help='subcommand that you want help for (optional)',
         )
+    add_verbosity_options(subparser)
 
     options = parser.parse_args(args)
+
+    verbosity = options.verbose - options.quiet
 
     if options.subcommand == 'add':
         cmd_add(parser, options)

--- a/bin/git-test
+++ b/bin/git-test
@@ -360,7 +360,7 @@ class Test(object):
             ]
         chatty_call(cmd)
 
-    def read_status(self, revision, revision_short):
+    def read_status(self, revision, revision_short=None):
         cmd = [
             'git', 'notes', '--ref=%s' % (self.notes_ref,),
             'show', '%s^{tree}' % (revision,),
@@ -373,7 +373,7 @@ class Test(object):
         if status not in ['good', 'bad']:
             raise Fatal(
                 'fatal: unrecognized status %r for tree %s^{tree}!'
-                % (status, revision_short),
+                % (status, revision_short or revision),
                 )
 
         return status
@@ -695,6 +695,27 @@ def cmd_run(parser, options):
         return
 
 
+def cmd_results(parser, options):
+    test = Test(options.test)
+
+    revisions = list(uniqify(iter_commits(parser, options)))
+
+    if not revisions:
+        sys.stderr.write('NO COMMITS SPECIFIED! (so none failed)\n')
+        return
+    elif revisions == ['HEAD']:
+        revisions = [rev_parse('HEAD')]
+
+    for r in revisions:
+        status = test.read_status(r)
+        if status == 'good':
+            sys.stdout.write('%s^{tree} known-good\n' % (r,))
+        elif status == 'bad':
+            sys.stdout.write('%s^{tree} known-bad\n' % (r,))
+        elif status == 'unknown':
+            sys.stdout.write('%s^{tree} unknown\n' % (r,))
+
+
 def cmd_forget_results(parser, options):
     test = Test(options.test)
 
@@ -863,6 +884,30 @@ def main(args):
     add_verbosity_options(subparser)
 
     subparser = subparsers.add_parser(
+        'results',
+        description=(
+            'Show any stored results for the specified commits.'
+            ),
+        help='show any stored test results for the specified commits',
+        )
+    subparser.add_argument(
+        '--test', '-t', metavar='name',
+        action='store', default='default',
+        help='name of test (default is \'default\')',
+        )
+    subparser.add_argument(
+        '--stdin', action='store_true',
+        help=(
+            'read the list of commits from standard input, one per line'
+            ),
+        )
+    subparser.add_argument(
+        'commits', nargs='*',
+        help='commits or ranges of commits',
+        )
+    add_verbosity_options(subparser)
+
+    subparser = subparsers.add_parser(
         'forget-results',
         description=(
             'Forget all stored test results for a test.'
@@ -918,6 +963,8 @@ def main(args):
         cmd_run(parser, options)
     elif options.subcommand == 'range':
         parser.error('the \'range\' subcommand has been renamed to \'run\'.')
+    elif options.subcommand == 'results':
+        cmd_results(parser, options)
     elif options.subcommand == 'forget-results':
         cmd_forget_results(parser, options)
     elif options.subcommand == 'remove':

--- a/bin/git-test
+++ b/bin/git-test
@@ -379,7 +379,7 @@ class Test(object):
 
         cmd = ['sh', '-c', self.command]
         try:
-            check_call(cmd)
+            check_call(cmd, stdout=sys.stderr)
         except CalledProcessError as e:
             raise UserTestError(e.returncode, e.cmd, e.output)
 
@@ -388,9 +388,9 @@ class Test(object):
             self.run()
         except UserTestError as e:
             cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
-            sys.stdout.write(FAIL_HEADER_TEMPLATE % dict(revision=revision))
-            check_call(cmd)
-            sys.stdout.write(FAIL_TRAILER_TEMPLATE % dict())
+            sys.stderr.write(FAIL_HEADER_TEMPLATE % dict(revision=revision))
+            check_call(cmd, stdout=sys.stderr)
+            sys.stderr.write(FAIL_TRAILER_TEMPLATE % dict())
             self.write_status(revision, 'bad')
             raise
         else:
@@ -414,13 +414,13 @@ class Test(object):
 def prepare_revision(r):
     cmd = ['git', 'checkout', r]
     try:
-        check_call(cmd)
+        check_output(cmd, stderr=subprocess.STDOUT)
     except CalledProcessError as e:
-        raise Fatal('fatal: error checking out commit %s' % (r,))
+        raise Fatal('fatal: error checking out commit %s:\n%s' % (r, e.output,))
 
     cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
     try:
-        check_call(cmd)
+        check_call(cmd, stdout=sys.stderr)
     except CalledProcessError as e:
         raise Fatal('fatal: error displaying log for commit %s' % (r,))
 
@@ -487,12 +487,12 @@ def cmd_run(parser, options):
         try:
             test.run()
         except UserTestError as e:
-            sys.stdout.write('\n!!! TEST FAILED !!!\n')
+            sys.stderr.write('\n!!! TEST FAILED !!!\n')
             sys.exit(e.returncode)
         else:
-            sys.stdout.write('\nTEST SUCCESSFUL\n')
+            sys.stderr.write('\nTEST SUCCESSFUL\n')
         finally:
-            sys.stdout.write(
+            sys.stderr.write(
                 'Note: working tree is dirty; results will not be saved.\n'
                 )
         return
@@ -530,7 +530,7 @@ def cmd_run(parser, options):
     revisions = list(uniqify(revisions))
 
     if not revisions:
-        sys.stdout.write('NO COMMITS SPECIFIED! (so none failed)\n')
+        sys.stderr.write('NO COMMITS SPECIFIED! (so none failed)\n')
         return
 
     try:
@@ -553,22 +553,21 @@ def cmd_run(parser, options):
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
         status = test.read_status(r, rs)
-        sys.stdout.write('Old status: %s\n' % (status,))
 
         if status == 'good':
-            sys.stdout.write('Tree %s^{tree} is already known to be good.\n' % (rs,))
+            sys.stderr.write('Tree %s^{tree} is already known to be good.\n' % (rs,))
             continue
 
         if status == 'bad':
             if options.retest:
-                sys.stdout.write(
+                sys.stderr.write(
                     'Tree %s^{tree} was previously tested to be bad; retesting...\n'
                     % (rs,)
                     )
                 status = 'unknown'
                 # fall through
             else:
-                sys.stdout.write('Tree %s^{tree} is already known to be bad!\n' % (rs,))
+                sys.stderr.write('Tree %s^{tree} is already known to be bad!\n' % (rs,))
                 status = 'failed'
                 if options.keep_going:
                     fail_count += 1
@@ -591,21 +590,21 @@ def cmd_run(parser, options):
 
     if not testing_head:
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
-        check_call(cmd)
+        check_call(cmd, stdout=sys.stderr)
 
-    sys.stdout.write('\n')
+    sys.stderr.write('\n')
     if fail_count > 0:
         if fail_count == 1:
-            sys.stdout.write('!!! %s TEST FAILED !!!\n' % (fail_count,))
+            sys.stderr.write('!!! %s TEST FAILED !!!\n' % (fail_count,))
         else:
-            sys.stdout.write('!!! %s TESTS FAILED !!!\n' % (fail_count,))
+            sys.stderr.write('!!! %s TESTS FAILED !!!\n' % (fail_count,))
 
         if last_failure is not None:
             sys.exit(last_failure)
         else:
             sys.exit(1)
     else:
-        sys.stdout.write('ALL TESTS SUCCESSFUL\n')
+        sys.stderr.write('ALL TESTS SUCCESSFUL\n')
         return
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -388,12 +388,14 @@ class Test(object):
             self.run()
         except UserTestError as e:
             cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
+            sys.stdout.write('%s^{tree} bad\n' % (revision,))
             sys.stderr.write(FAIL_HEADER_TEMPLATE % dict(revision=revision))
             check_call(cmd, stdout=sys.stderr)
             sys.stderr.write(FAIL_TRAILER_TEMPLATE % dict())
             self.write_status(revision, 'bad')
             raise
         else:
+            sys.stdout.write('%s^{tree} good\n' % (revision,))
             self.write_status(revision, 'good')
 
     def remove_status(self, msg):
@@ -487,9 +489,11 @@ def cmd_run(parser, options):
         try:
             test.run()
         except UserTestError as e:
+            sys.stdout.write('working-tree bad\n')
             sys.stderr.write('\n!!! TEST FAILED !!!\n')
             sys.exit(e.returncode)
         else:
+            sys.stdout.write('working-tree good\n')
             sys.stderr.write('\nTEST SUCCESSFUL\n')
         finally:
             sys.stderr.write(
@@ -555,18 +559,19 @@ def cmd_run(parser, options):
         status = test.read_status(r, rs)
 
         if status == 'good':
+            sys.stdout.write('%s^{tree} known-good\n' % (r,))
             sys.stderr.write('Tree %s^{tree} is already known to be good.\n' % (rs,))
-            continue
 
-        if status == 'bad':
+        elif status == 'bad':
             if options.retest:
                 sys.stderr.write(
                     'Tree %s^{tree} was previously tested to be bad; retesting...\n'
                     % (rs,)
                     )
-                status = 'unknown'
+                status = None
                 # fall through
             else:
+                sys.stdout.write('%s^{tree} known-bad\n' % (r,))
                 sys.stderr.write('Tree %s^{tree} is already known to be bad!\n' % (rs,))
                 status = 'failed'
                 if options.keep_going:
@@ -574,7 +579,10 @@ def cmd_run(parser, options):
                 else:
                     sys.exit(1)
 
-        if status == 'unknown':
+        elif status == 'unknown':
+            status = None
+
+        if status is None:
             if not testing_head:
                 prepare_revision(r)
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -527,6 +527,36 @@ def cmd_add(parser, options):
         test.initialize_status('Test results initialized by \'git test add\'')
 
 
+def iter_commits(parser, options):
+    """Iterate over the commits specified by the user.
+
+    Yield the special value 'HEAD' if the current checked-out version
+    should be tested."""
+
+    revisions = []
+
+    if (not options.commits or options.commits == ['HEAD']) and not options.stdin:
+        yield 'HEAD'
+        return
+
+    for arg in options.commits:
+        limits = arg.split('..')
+        if len(limits) == 1:
+            yield rev_parse('%s^{commit}' % (arg,))
+        elif len(limits) == 2:
+            for revision in rev_list('--reverse', arg):
+                yield revision
+        else:
+            parser.error(
+                'commit arguments must be single commits '
+                'or of the form \'A..B\''
+                )
+
+    if options.stdin:
+        for arg in sys.stdin:
+            yield rev_parse('%s^{commit}' % (arg.strip(),))
+
+
 def cmd_run(parser, options):
     test = Test(options.test)
 
@@ -558,41 +588,16 @@ def cmd_run(parser, options):
                 )
         return
 
-    revisions = []
-
-    if options.stdin:
-        testing_head = False
-    elif not options.commits:
-        revisions.append(rev_parse('HEAD'))
-        testing_head = True
-    elif options.commits == ['HEAD']:
-        testing_head = True
-    else:
-        testing_head = False
-
-    for arg in options.commits:
-        limits = arg.split('..')
-        if len(limits) == 1:
-            revisions.append(rev_parse('%s^{commit}' % (arg,)))
-        elif len(limits) == 2:
-            revisions.extend(rev_list('--reverse', arg))
-        else:
-            parser.error(
-                'commit arguments must be single commits '
-                'or of the form \'A..B\''
-                )
-
-    if options.stdin:
-        revisions.extend(
-            rev_parse('%s^{commit}' % (arg.strip(),))
-            for arg in sys.stdin
-            )
-
-    revisions = list(uniqify(revisions))
+    revisions = list(uniqify(iter_commits(parser, options)))
 
     if not revisions:
         sys.stderr.write('NO COMMITS SPECIFIED! (so none failed)\n')
         return
+    elif revisions == ['HEAD']:
+        testing_head = True
+        revisions = [rev_parse('HEAD')]
+    else:
+        testing_head = False
 
     try:
         cmd = ['git', 'symbolic-ref', 'HEAD']

--- a/test/run.t
+++ b/test/run.t
@@ -398,6 +398,14 @@ test_expect_success 'default (retcodes): force test range' '
 	test_cmp expected numbers.log
 '
 
+test_expect_success 'default (retcodes): list results' '
+	rm -f numbers.log &&
+	gen_stdout c2 unknown c3 unknown c4 known-good c5 known-bad c6 unknown c7 unknown c8 unknown >expected-stdout &&
+	git-test results c1..c8 >actual-stdout &&
+	test_cmp expected-stdout actual-stdout &&
+	test_must_fail test -f numbers.log
+'
+
 test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 	rm -f numbers.log &&
 	gen_stdout c2 good c3 bad c4 good c5 bad c6 good >expected-stdout &&

--- a/test/run.t
+++ b/test/run.t
@@ -177,6 +177,20 @@ test_expect_success 'default (failing-4-7-8): do not re-test known commits' '
 	test_must_fail test -f numbers.log
 '
 
+test_expect_success 'default (failing-4-7-8): --dry-run' '
+	rm -f numbers.log &&
+	test_expect_code 1 git-test run --dry-run c1..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c2 unknown c3 known-good c4 known-bad &&
+	test_must_fail test -f numbers.log
+'
+
+test_expect_success 'default (failing-4-7-8): --dry-run --keep-going' '
+	rm -f numbers.log &&
+	test_expect_code 1 git-test run --dry-run --keep-going c1..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c2 unknown c3 known-good c4 known-bad c5 unknown c6 unknown &&
+	test_must_fail test -f numbers.log
+'
+
 test_expect_success 'default (failing-4-7-8): do not re-test known subrange' '
 	rm -f numbers.log &&
 	test_expect_code 1 git-test run c1..c6 >actual-stdout &&
@@ -294,6 +308,18 @@ test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 	printf "default %s${LF}" 42 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c4^{tree}
+'
+
+test_expect_success 'default (failing-4-7-8): cannot test dirty working copy woth --dry-run' '
+	echo 111 >number &&
+	test_when_finished "git reset --hard HEAD" &&
+	test_expect_code 125 git-test run --dry-run
+'
+
+test_expect_success 'default (failing-4-7-8): cannot test dirty working copy woth --forget' '
+	echo 111 >number &&
+	test_when_finished "git reset --hard HEAD" &&
+	test_expect_code 125 git-test run --forget
 '
 
 test_expect_success 'default (failing-4-7-8): test failing dirty working copy' '

--- a/test/run.t
+++ b/test/run.t
@@ -4,6 +4,19 @@ test_description="Test basic features"
 
 . ./sharness.sh
 
+# Usage: cmp_stdout actual [commit status]...
+cmp_stdout() {
+	local actual=$1 &&
+	shift &&
+
+	while test $# -gt 0
+	do
+		echo "$(git rev-parse $1)^{tree} $2" &&
+		shift 2
+	done >expected-stdout &&
+	test_cmp expected-stdout "$actual"
+}
+
 # The test repository consists of a linear chain of numbered commits.
 # Each commit contains a file "number" containing the number of the
 # commit. Each commit is pointed at by a branch "c<number>".
@@ -27,7 +40,8 @@ test_expect_success 'Set up test repository' '
 test_expect_success 'default (passing): test range' '
 	git-test add "test-number --log=numbers.log --good \*" &&
 	rm -f numbers.log &&
-	git-test run c2..c6 &&
+	git-test run c2..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c3 good c4 good c5 good c6 good &&
 	printf "default %s${LF}" 3 4 5 6 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -40,34 +54,39 @@ test_expect_success 'default (passing): test range' '
 
 test_expect_success 'default (passing): do not re-test known-good commits' '
 	rm -f numbers.log &&
-	git-test run c3..c5 &&
+	git-test run c3..c5 >actual-stdout &&
+	cmp_stdout actual-stdout c4 known-good c5 known-good &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (passing): do not re-test known-good subrange' '
 	rm -f numbers.log &&
-	git-test run c1..c7 &&
+	git-test run c1..c7 >actual-stdout &&
+	cmp_stdout actual-stdout c2 good c3 known-good c4 known-good c5 known-good c6 known-good c7 good &&
 	printf "default %s${LF}" 2 7 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): do not retest known-good even with --retest' '
 	rm -f numbers.log &&
-	git-test run --retest c0..c8 &&
+	git-test run --retest c0..c8 >actual-stdout &&
+	cmp_stdout actual-stdout c1 good c2 known-good c3 known-good c4 known-good c5 known-good c6 known-good c7 known-good c8 good &&
 	printf "default %s${LF}" 1 8 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): retest with --force' '
 	rm -f numbers.log &&
-	git-test run --force c5..c9 &&
+	git-test run --force c5..c9 >actual-stdout &&
+	cmp_stdout actual-stdout c6 good c7 good c8 good c9 good &&
 	printf "default %s${LF}" 6 7 8 9 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): forget some results' '
 	rm -f numbers.log &&
-	git-test run --forget c4..c7 &&
+	git-test run --forget c4..c7 >actual-stdout &&
+	cmp_stdout actual-stdout &&
 	test_must_fail test -f numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c5^{tree} &&
 	test_must_fail git notes --ref=tests/default show $c7^{tree}
@@ -75,7 +94,8 @@ test_expect_success 'default (passing): forget some results' '
 
 test_expect_success 'default (passing): retest forgotten commits' '
 	rm -f numbers.log &&
-	git-test run c3..c8 &&
+	git-test run c3..c8 >actual-stdout &&
+	cmp_stdout actual-stdout c4 known-good c5 good c6 good c7 good c8 known-good &&
 	printf "default %s${LF}" 5 6 7 >expected &&
 	test_cmp expected numbers.log
 '
@@ -83,15 +103,16 @@ test_expect_success 'default (passing): retest forgotten commits' '
 test_expect_success 'default (passing): test a single commit' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	git-test run c5 &&
+	git-test run c5 >actual-stdout &&
+	cmp_stdout actual-stdout c5 good &&
 	printf "default %s${LF}" 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (passing): test a few single commits' '
-	git-test forget-results &&
 	rm -f numbers.log &&
-	git-test run c2 c6 c4 &&
+	git-test run c2 c6 c5 c4 >actual-stdout &&
+	cmp_stdout actual-stdout c2 good c6 good c5 known-good c4 good &&
 	printf "default %s${LF}" 2 6 4 >expected &&
 	test_cmp expected numbers.log
 '
@@ -99,7 +120,8 @@ test_expect_success 'default (passing): test a few single commits' '
 test_expect_success 'default (passing): test a single commit and a range' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	git-test run c9 c4..c6 &&
+	git-test run c9 c4..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c9 good c5 good c6 good &&
 	printf "default %s${LF}" 9 5 6 >expected &&
 	test_cmp expected numbers.log
 '
@@ -107,7 +129,8 @@ test_expect_success 'default (passing): test a single commit and a range' '
 test_expect_success 'default (passing): commits uniqified' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	git-test run c4..c6 c8 c5 c3..c9 &&
+	git-test run c4..c6 c8 c5 c3..c9 >actual-stdout &&
+	cmp_stdout actual-stdout c5 good c6 good c8 good c4 good c7 good c9 good &&
 	printf "default %s${LF}" 5 6 8 4 7 9 >expected &&
 	test_cmp expected numbers.log
 '
@@ -115,7 +138,8 @@ test_expect_success 'default (passing): commits uniqified' '
 test_expect_success 'default (passing): read commits from stdin' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	git rev-list c2..c6 | git-test run --stdin &&
+	git rev-list c2..c6 | git-test run --stdin >actual-stdout &&
+	cmp_stdout actual-stdout c6 good c5 good c4 good c3 good &&
 	printf "default %s${LF}" 6 5 4 3 >expected &&
 	test_cmp expected numbers.log
 '
@@ -123,7 +147,8 @@ test_expect_success 'default (passing): read commits from stdin' '
 test_expect_success 'default (passing): combine args and stdin' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	git rev-list c2..c6 | git-test run --stdin c5 c8 &&
+	git rev-list c2..c6 | git-test run --stdin c5 c8 >actual-stdout &&
+	cmp_stdout actual-stdout c5 good c8 good c6 good c4 good c3 good &&
 	# Note that rev-list was called without --reverse:
 	printf "default %s${LF}" 5 8 6 4 3 >expected &&
 	test_cmp expected numbers.log
@@ -133,7 +158,8 @@ test_expect_success 'default (failing-4-7-8): test range' '
 	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 666 --good \*" &&
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run c2..c5 &&
+	test_expect_code 1 git-test run c2..c5 >actual-stdout &&
+	cmp_stdout actual-stdout c3 good c4 bad &&
 	printf "default %s${LF}" 3 4 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -146,20 +172,23 @@ test_expect_success 'default (failing-4-7-8): test range' '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known commits' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run c2..c5 &&
+	test_expect_code 1 git-test run c2..c5 >actual-stdout &&
+	cmp_stdout actual-stdout c3 known-good c4 known-bad &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known subrange' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run c1..c6 &&
+	test_expect_code 1 git-test run c1..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c2 good c3 known-good c4 known-bad &&
 	printf "default %s${LF}" 2 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (failing-4-7-8): retest known-bad with --retest' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run --retest c1..c6 &&
+	test_expect_code 1 git-test run --retest c1..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c2 known-good c3 known-good c4 bad &&
 	printf "default %s${LF}" 4 >expected &&
 	test_cmp expected numbers.log
 '
@@ -168,7 +197,8 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 	# Test a good commit past the failing one:
 	git-test run c5..c6 &&
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run --force c2..c6 &&
+	test_expect_code 1 git-test run --force c2..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c3 good c4 bad &&
 	printf "default %s${LF}" 3 4 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c5^{tree} &&
@@ -179,7 +209,8 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 test_expect_success 'default (failing-4-7-8): test --keep-going' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run --keep-going c2..c9 &&
+	test_expect_code 1 git-test run --keep-going c2..c9 >actual-stdout &&
+	cmp_stdout actual-stdout c3 good c4 bad c5 good c6 good c7 bad c8 bad c9 good &&
 	printf "default %s${LF}" 3 4 5 6 7 8 9 >expected &&
 	test_cmp expected numbers.log &&
 	test_must_fail git notes --ref=tests/default show $c2^{tree} &&
@@ -197,7 +228,8 @@ test_expect_success 'default (failing-4-7-8): test --keep-going' '
 
 test_expect_success 'default (failing-4-7-8): retest disjoint commits with --keep-going' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run --retest --keep-going c2..c9 &&
+	test_expect_code 1 git-test run --retest --keep-going c2..c9 >actual-stdout &&
+	cmp_stdout actual-stdout c3 known-good c4 bad c5 known-good c6 known-good c7 bad c8 bad c9 known-good &&
 	printf "default %s${LF}" 4 7 8 >expected &&
 	test_cmp expected numbers.log
 '
@@ -207,7 +239,8 @@ test_expect_success 'default (failing-4-7-8): test passing HEAD' '
 	rm -f numbers.log &&
 	git checkout c2 &&
 	git symbolic-ref HEAD >expected-branch &&
-	git-test run &&
+	git-test run >actual-stdout &&
+	cmp_stdout actual-stdout c2 good &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 2 >expected &&
@@ -221,7 +254,8 @@ test_expect_success 'default (failing-4-7-8): test failing HEAD' '
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
-	test_expect_code 1 git-test run &&
+	test_expect_code 1 git-test run >actual-stdout &&
+	cmp_stdout actual-stdout c4 bad &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 4 >expected &&
@@ -235,7 +269,8 @@ test_expect_success 'default (failing-4-7-8): test failing explicit HEAD' '
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
-	test_expect_code 1 git-test run HEAD &&
+	test_expect_code 1 git-test run HEAD >actual-stdout &&
+	cmp_stdout actual-stdout c4 bad &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 4 >expected &&
@@ -251,7 +286,9 @@ test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 	git symbolic-ref HEAD >expected-branch &&
 	echo 42 >number &&
 	test_when_finished "git reset --hard HEAD" &&
-	git-test run &&
+	git-test run >actual-stdout &&
+	echo "working-tree good" >expected-stdout &&
+	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 42 >expected &&
@@ -266,7 +303,9 @@ test_expect_success 'default (failing-4-7-8): test failing dirty working copy' '
 	git symbolic-ref HEAD >expected-branch &&
 	echo 666 >number &&
 	test_when_finished "git reset --hard HEAD" &&
-	test_expect_code 1 git-test run &&
+	test_expect_code 1 git-test run >actual-stdout &&
+	echo "working-tree bad" >expected-stdout &&
+	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
 	printf "default %s${LF}" 666 >expected &&
@@ -278,7 +317,8 @@ test_expect_success 'default (retcodes): test range' '
 	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 3 7 --ret=42 5 --good \*" &&
 	rm -f numbers.log &&
-	test_expect_code 42 git-test run c3..c6 &&
+	test_expect_code 42 git-test run c3..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c4 good c5 bad &&
 	printf "default %s${LF}" 4 5 >expected &&
 	test_cmp expected numbers.log
 '
@@ -286,34 +326,39 @@ test_expect_success 'default (retcodes): test range' '
 test_expect_success 'default (retcodes): test range again' '
 	# We do not remember return codes (should we?):
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run c3..c6 &&
+	test_expect_code 1 git-test run c3..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c4 known-good c5 known-bad &&
 	test_must_fail test -f numbers.log
 '
 
 test_expect_success 'default (retcodes): retest range' '
 	rm -f numbers.log &&
-	test_expect_code 42 git-test run --retest c3..c6 &&
+	test_expect_code 42 git-test run --retest c3..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c4 known-good c5 bad &&
 	printf "default %s${LF}" 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): force test range' '
 	rm -f numbers.log &&
-	test_expect_code 42 git-test run --force c3..c6 &&
+	test_expect_code 42 git-test run --force c3..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c4 good c5 bad &&
 	printf "default %s${LF}" 4 5 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 	rm -f numbers.log &&
-	test_expect_code 42 git-test run --force --keep-going c1..c6 &&
+	test_expect_code 42 git-test run --force --keep-going c1..c6 >actual-stdout &&
+	cmp_stdout actual-stdout c2 good c3 bad c4 good c5 bad c6 good &&
 	printf "default %s${LF}" 2 3 4 5 6 >expected &&
 	test_cmp expected numbers.log
 '
 
 test_expect_success 'default (retcodes): keep-going: bad wins if last' '
 	rm -f numbers.log &&
-	test_expect_code 1 git-test run --force --keep-going c1..c8 &&
+	test_expect_code 1 git-test run --force --keep-going c1..c8 >actual-stdout &&
+	cmp_stdout actual-stdout c2 good c3 bad c4 good c5 bad c6 good c7 bad c8 good &&
 	printf "default %s${LF}" 2 3 4 5 6 7 8 >expected &&
 	test_cmp expected numbers.log
 '


### PR DESCRIPTION
`git test run` used to spew output (from itself, from the user test script, and from `git` command that it invoked to do its work) willy-nilly, partly to stdout and partly to stderr. Instead

* Redirect all existing output to stderr.
* Write (only) machine-readable output to stdout, in the following format:

        3232673f675f82ddf410e15091e1d945066be69c^{tree} known-good
        c30b40080b2bc2389d0dda702ffe0646b44dcad0^{tree} good
        8901449fa372099379c30cd2fc84faa3d89a7386^{tree} good
        aa237947bd25b1042ddf015dd5fde2c4d670858d^{tree} known-bad

* Add options `--verbose`/`-v` and `--quiet`/`-q`, which can be used to adjust the amount of output written to stderr; roughly:

    * `-v`: write all output of all commands
    * no option: write all output of test commands plus output of any other commands that fail
    * `-q`: write the output only of test commands that fail
    * `-qq`: don't write anything to stderr

* Add a new `git test run` option, `--dry-run`, that replays old cached results without running any new tests. Any results that are not yet known are listed as `unknown`.
* Add a new subcommand, `results`, that can be used to display the cached results for an arbitrary set of commits in the above format. Any results that are not yet known are listed as `unknown`.

The hope is that all of these new features will make it easier to call `git test` from other scripts (plus allow users to adjust its level of verbosity).

/cc @peff, who wanted to use `git test` as part of a CI system.
