### PR TITLE
Use screen colours to print results

### DIFF
--- a/bin/git-test
+++ b/bin/git-test
@@ -108,7 +108,10 @@ def colored(text, color):
     Example:
     print('Save changes? ' + colored('Yes', AnsiColor.GREEN) + '/' + colored('No', AnsiColor.RED))
     """
-    return color + text + AnsiColor.END
+    if text[-1] == '\n':
+        return color + text[:-1] + AnsiColor.END + '\n'
+    else:
+        return color + text + AnsiColor.END
 
 def good_bad_text(value):
     if value == 'good' or value == 'known-good':

--- a/bin/git-test
+++ b/bin/git-test
@@ -65,7 +65,13 @@ import argparse
 
 # https://pypi.org/project/colorama/
 from colorama import Fore, Back, Style, init
-init()
+
+if os.environ.get('OS') != 'Windows_NT' or os.environ.get('MSYSTEM') != 'MINGW64':
+    # Skip calling init for (most likely) a "Git Bash" window from the
+    # "Git for windows" program. It handle ANSI colour codes fine, and
+    # calling init will actually result in no color.
+    # Probably related to https://github.com/tartley/colorama/issues/104.
+    init()
 
 def colored(text, color):
     """Super simple version of colored from https://pypi.org/project/termcolor/

--- a/bin/git-test
+++ b/bin/git-test
@@ -468,10 +468,10 @@ class Test(object):
         except UserTestError as e:
             sys.stdout.write('%s^{tree} bad\n' % (revision,))
             if verbosity >= -1:
-                sys.stderr.write(FAIL_HEADER_TEMPLATE % dict(revision=revision))
+                sys.stderr.write(colored(FAIL_HEADER_TEMPLATE % dict(revision=revision), Fore.RED))
                 cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
                 chatty_call(cmd, level=-1)
-                sys.stderr.write(FAIL_TRAILER_TEMPLATE % dict())
+                sys.stderr.write(colored(FAIL_TRAILER_TEMPLATE % dict(), Fore.RED))
                 self.write_status(revision, 'bad')
             raise
         else:
@@ -540,7 +540,7 @@ def cmd_add(parser, options):
                 # results and the user didn't explicitly ask for
                 # `--keep`; emit a warning in case the user forgot to
                 # `--forget`:
-                sys.stderr.write(REUSE_RESULTS_WARNING % dict(name=test.name))
+                sys.stderr.write(colored(REUSE_RESULTS_WARNING % dict(name=test.name), Fore.YELLOW))
 
     if initialize:
         test.initialize_status('Test results initialized by \'git test add\'')
@@ -595,12 +595,12 @@ def cmd_run(parser, options):
         except UserTestError as e:
             sys.stdout.write('working-tree bad\n')
             if verbosity >= -1:
-                sys.stderr.write('\n!!! TEST FAILED !!!\n')
+                sys.stderr.write(colored('\n!!! TEST FAILED !!!\n', Fore.RED))
             sys.exit(e.returncode)
         else:
             sys.stdout.write('working-tree good\n')
             if verbosity >= -1:
-                sys.stderr.write('\nTEST SUCCESSFUL\n')
+                sys.stderr.write(colored('\nTEST SUCCESSFUL\n', Fore.GREEN))
         finally:
             sys.stderr.write(
                 'Note: working tree is dirty; results will not be saved.\n'
@@ -692,7 +692,7 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text))
+            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text), Fore.RED))
 
         if last_failure is not None:
             sys.exit(last_failure)
@@ -704,7 +704,7 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write('\n%s %s UNKNOWN\n' % (unknown_count, test_text))
+            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (unknown_count, test_text), Fore.YELLOW))
 
         sys.exit(2)
     else:

--- a/bin/git-test
+++ b/bin/git-test
@@ -63,36 +63,65 @@ import re
 import subprocess
 import argparse
 
-# https://pypi.org/project/colorama/
-from colorama import Fore, Back, Style, init
+class AnsiColor:
+    BLACK = '\033[0;30m'
+    RED = '\033[0;31m'
+    GREEN = '\033[0;32m'
+    YELLOW = '\033[0;33m'
+    BLUE = '\033[0;34m'
+    MAGENTA = '\033[0;35m'
+    CYAN = '\033[0;36m'
+    B_GRAY = '\033[0;37m'
+    D_GRAY = '\033[1;30m'
+    B_RED = '\033[1;31m'
+    B_GREEN = '\033[1;32m'
+    B_YELLOW = '\033[1;33m'
+    B_BLUE = '\033[1;34m'
+    B_MAGENTA = '\033[1;35m'
+    B_CYAN = '\033[1;36m'
+    WHITE = '\033[1;37m'
+    END = '\033[0m'
 
-if os.environ.get('OS') != 'Windows_NT' or os.environ.get('MSYSTEM') != 'MINGW64':
-    # Skip calling init for (most likely) a "Git Bash" window from the
-    # "Git for windows" program. It handle ANSI colour codes fine, and
-    # calling init will actually result in no color.
-    # Probably related to https://github.com/tartley/colorama/issues/104.
-    init()
+    @classmethod
+    def disable(cls):
+        cls.BLACK = ''
+        cls.RED = ''
+        cls.GREEN = ''
+        cls.YELLOW = ''
+        cls.BLUE = ''
+        cls.MAGENTA = ''
+        cls.CYAN = ''
+        cls.B_GRAY = ''
+        cls.D_GRAY = ''
+        cls.B_RED = ''
+        cls.B_GREEN = ''
+        cls.B_YELLOW = ''
+        cls.B_BLUE = ''
+        cls.B_MAGENTA = ''
+        cls.B_CYAN = ''
+        cls.WHITE = ''
+        cls.END = ''
 
 def colored(text, color):
-    """Super simple version of colored from https://pypi.org/project/termcolor/
+    """Super simple function similar to colored from https://pypi.org/project/termcolor/
 
     Example:
-    print('Save changes? ' + colored('Yes', Fore.GREEN) + '/' + colored('No', Fore.RED))
+    print('Save changes? ' + colored('Yes', AnsiColor.GREEN) + '/' + colored('No', AnsiColor.RED))
     """
-    return color + text + Style.RESET_ALL
+    return color + text + AnsiColor.END
 
 def good_bad_text(value):
     if value == 'good' or value == 'known-good':
-        return colored(value, Fore.GREEN)
+        return colored(value, AnsiColor.GREEN)
     if value == 'bad' or value == 'known-bad':
-        return colored(value, Fore.RED)
+        return colored(value, AnsiColor.RED)
     if value == 'unknown':
-        return colored(value, Fore.YELLOW)
+        return colored(value, AnsiColor.YELLOW)
     return value
 
 
 if not (0x02060000 <= sys.hexversion):
-    sys.stderr.write(colored('fatal: Python version 2.6 or later is required', Fore.RED))
+    sys.stderr.write(colored('fatal: Python version 2.6 or later is required', AnsiColor.RED))
     sys.exit(125)
 
 
@@ -476,10 +505,10 @@ class Test(object):
         except UserTestError as e:
             sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('bad')))
             if verbosity >= -1:
-                sys.stderr.write(colored(FAIL_HEADER_TEMPLATE % dict(revision=revision), Fore.RED))
+                sys.stderr.write(colored(FAIL_HEADER_TEMPLATE % dict(revision=revision), AnsiColor.RED))
                 cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
                 chatty_call(cmd, level=-1)
-                sys.stderr.write(colored(FAIL_TRAILER_TEMPLATE % dict(), Fore.RED))
+                sys.stderr.write(colored(FAIL_TRAILER_TEMPLATE % dict(), AnsiColor.RED))
                 self.write_status(revision, 'bad')
             raise
         else:
@@ -548,7 +577,7 @@ def cmd_add(parser, options):
                 # results and the user didn't explicitly ask for
                 # `--keep`; emit a warning in case the user forgot to
                 # `--forget`:
-                sys.stderr.write(colored(REUSE_RESULTS_WARNING % dict(name=test.name), Fore.YELLOW))
+                sys.stderr.write(colored(REUSE_RESULTS_WARNING % dict(name=test.name), AnsiColor.YELLOW))
 
     if initialize:
         test.initialize_status('Test results initialized by \'git test add\'')
@@ -588,7 +617,7 @@ def cmd_run(parser, options):
     test = Test(options.test)
 
     if verbosity >= 0:
-        sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, Fore.YELLOW), colored(test.command, Fore.YELLOW)))
+        sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.YELLOW), colored(test.command, AnsiColor.YELLOW)))
 
     try:
         require_clean_work_tree('test-run')
@@ -603,12 +632,12 @@ def cmd_run(parser, options):
         except UserTestError as e:
             sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
             if verbosity >= -1:
-                sys.stderr.write(colored('\n!!! TEST FAILED !!!\n', Fore.RED))
+                sys.stderr.write(colored('\n!!! TEST FAILED !!!\n', AnsiColor.RED))
             sys.exit(e.returncode)
         else:
             sys.stdout.write('working-tree %s\n' % good_bad_text('good'))
             if verbosity >= -1:
-                sys.stderr.write(colored('\nTEST SUCCESSFUL\n', Fore.GREEN))
+                sys.stderr.write(colored('\nTEST SUCCESSFUL\n', AnsiColor.GREEN))
         finally:
             sys.stderr.write(
                 'Note: working tree is dirty; results will not be saved.\n'
@@ -700,7 +729,7 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text), Fore.RED))
+            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text), AnsiColor.RED))
 
         if last_failure is not None:
             sys.exit(last_failure)
@@ -712,12 +741,12 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (unknown_count, test_text), Fore.YELLOW))
+            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (unknown_count, test_text), AnsiColor.YELLOW))
 
         sys.exit(2)
     else:
         if verbosity >= -1:
-            sys.stderr.write(colored('\nALL TESTS SUCCESSFUL\n', Fore.GREEN))
+            sys.stderr.write(colored('\nALL TESTS SUCCESSFUL\n', AnsiColor.GREEN))
         return
 
 
@@ -1005,7 +1034,7 @@ if __name__ == '__main__':
     try:
         main(sys.argv[1:])
     except Fatal as e:
-        sys.stderr.write(colored('\nERROR!\n%s\n\n' % (e,), Fore.RED))
+        sys.stderr.write(colored('\nERROR!\n%s\n\n' % (e,), AnsiColor.RED))
         sys.exit(125)
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -1022,6 +1022,10 @@ def main(args):
     if not (options.color and sys.stdout.isatty()):
         AnsiColor.disable()
 
+    isCmdOrPowershell = (os.getenv('PROMPT', '') == '$P$G')
+    if isCmdOrPowershell:
+        AnsiColor.disable()
+
     # Expose the verbosity to child processes, in case they want to
     # adjust their output levels, too:
     os.environ['GIT_TEST_VERBOSITY'] = str(verbosity)

--- a/bin/git-test
+++ b/bin/git-test
@@ -687,7 +687,7 @@ def cmd_run(parser, options):
         elif status == 'bad':
             if options.retest and not options.dry_run:
                 sys.stderr.write(
-                    'Tree %s^{tree} was previously tested to be %; retesting...\n'
+                    'Tree %s^{tree} was previously tested to be %s; retesting...\n'
                     % (rs, good_bad_text('bad'))
                     )
                 status = None

--- a/bin/git-test
+++ b/bin/git-test
@@ -688,11 +688,11 @@ def cmd_run(parser, options):
 
     if fail_count > 0:
         if verbosity >= -1:
-            sys.stderr.write('\n')
             if fail_count == 1:
-                sys.stderr.write('!!! %s TEST FAILED !!!\n' % (fail_count,))
+                test_text = 'TEST'
             else:
-                sys.stderr.write('!!! %s TESTS FAILED !!!\n' % (fail_count,))
+                test_text = 'TESTS'
+            sys.stderr.write('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text))
 
         if last_failure is not None:
             sys.exit(last_failure)
@@ -700,17 +700,16 @@ def cmd_run(parser, options):
             sys.exit(1)
     elif unknown_count > 0:
         if verbosity >= -1:
-            sys.stderr.write('\n')
             if unknown_count == 1:
-                sys.stderr.write('%s TEST UNKNOWN\n' % (unknown_count,))
+                test_text = 'TEST'
             else:
-                sys.stderr.write('%s TESTS UNKNOWN\n' % (unknown_count,))
+                test_text = 'TESTS'
+            sys.stderr.write('\n%s %s UNKNOWN\n' % (unknown_count, test_text))
 
         sys.exit(2)
     else:
         if verbosity >= -1:
-            sys.stderr.write('\n')
-            sys.stderr.write('ALL TESTS SUCCESSFUL\n')
+            sys.stderr.write(colored('\nALL TESTS SUCCESSFUL\n', Fore.GREEN))
         return
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -81,6 +81,14 @@ def colored(text, color):
     """
     return color + text + Style.RESET_ALL
 
+def good_bad_text(value):
+    if value == 'good' or value == 'known-good':
+        return colored(value, Fore.GREEN)
+    if value == 'bad' or value == 'known-bad':
+        return colored(value, Fore.RED)
+    if value == 'unknown':
+        return colored(value, Fore.YELLOW)
+    return value
 
 
 if not (0x02060000 <= sys.hexversion):
@@ -408,7 +416,7 @@ class Test(object):
             raise Fatal('fatal: error adding note to %s^{tree}' % (revision,))
         else:
             if verbosity >= 0:
-                sys.stderr.write('Marked tree %s^{tree} to be %s\n' % (revision, value))
+                sys.stderr.write('Marked tree %s^{tree} to be %s\n' % (revision, good_bad_text(value)))
 
     def forget_status(self, revisions):
         """Forget the stored results (if any) for the specified revisions."""
@@ -466,7 +474,7 @@ class Test(object):
         try:
             self.run()
         except UserTestError as e:
-            sys.stdout.write('%s^{tree} bad\n' % (revision,))
+            sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('bad')))
             if verbosity >= -1:
                 sys.stderr.write(colored(FAIL_HEADER_TEMPLATE % dict(revision=revision), Fore.RED))
                 cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
@@ -475,7 +483,7 @@ class Test(object):
                 self.write_status(revision, 'bad')
             raise
         else:
-            sys.stdout.write('%s^{tree} good\n' % (revision,))
+            sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('good')))
             self.write_status(revision, 'good')
 
     def remove_status(self, msg):
@@ -593,12 +601,12 @@ def cmd_run(parser, options):
         try:
             test.run()
         except UserTestError as e:
-            sys.stdout.write('working-tree bad\n')
+            sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
             if verbosity >= -1:
                 sys.stderr.write(colored('\n!!! TEST FAILED !!!\n', Fore.RED))
             sys.exit(e.returncode)
         else:
-            sys.stdout.write('working-tree good\n')
+            sys.stdout.write('working-tree %s\n' % good_bad_text('good'))
             if verbosity >= -1:
                 sys.stderr.write(colored('\nTEST SUCCESSFUL\n', Fore.GREEN))
         finally:
@@ -641,20 +649,20 @@ def cmd_run(parser, options):
         status = test.read_status(r, rs)
 
         if status == 'good':
-            sys.stdout.write('%s^{tree} known-good\n' % (r,))
-            sys.stderr.write('Tree %s^{tree} is already known to be good.\n' % (rs,))
+            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
+            sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
 
         elif status == 'bad':
             if options.retest and not options.dry_run:
                 sys.stderr.write(
-                    'Tree %s^{tree} was previously tested to be bad; retesting...\n'
-                    % (rs,)
+                    'Tree %s^{tree} was previously tested to be %; retesting...\n'
+                    % (rs, good_bad_text('bad'))
                     )
                 status = None
                 # fall through
             else:
-                sys.stdout.write('%s^{tree} known-bad\n' % (r,))
-                sys.stderr.write('Tree %s^{tree} is already known to be bad!\n' % (rs,))
+                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
+                sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
                 status = 'failed'
                 if options.keep_going:
                     fail_count += 1
@@ -663,7 +671,7 @@ def cmd_run(parser, options):
 
         elif status == 'unknown':
             if options.dry_run:
-                sys.stdout.write('%s^{tree} unknown\n' % (r,))
+                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
                 unknown_count += 1
             else:
                 status = None
@@ -727,11 +735,11 @@ def cmd_results(parser, options):
     for r in revisions:
         status = test.read_status(r)
         if status == 'good':
-            sys.stdout.write('%s^{tree} known-good\n' % (r,))
+            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
         elif status == 'bad':
-            sys.stdout.write('%s^{tree} known-bad\n' % (r,))
+            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
         elif status == 'unknown':
-            sys.stdout.write('%s^{tree} unknown\n' % (r,))
+            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
 
 
 def cmd_forget_results(parser, options):

--- a/bin/git-test
+++ b/bin/git-test
@@ -63,6 +63,19 @@ import re
 import subprocess
 import argparse
 
+# https://pypi.org/project/colorama/
+from colorama import Fore, Back, Style, init
+init()
+
+def colored(text, color):
+    """Super simple version of colored from https://pypi.org/project/termcolor/
+
+    Example:
+    print('Save changes? ' + colored('Yes', Fore.GREEN) + '/' + colored('No', Fore.RED))
+    """
+    return color + text + Style.RESET_ALL
+
+
 
 if not (0x02060000 <= sys.hexversion):
     sys.stderr.write('fatal: Python version 2.6 or later is required')

--- a/bin/git-test
+++ b/bin/git-test
@@ -84,7 +84,7 @@ def colored(text, color):
 
 
 if not (0x02060000 <= sys.hexversion):
-    sys.stderr.write('fatal: Python version 2.6 or later is required')
+    sys.stderr.write(colored('fatal: Python version 2.6 or later is required', Fore.RED))
     sys.exit(125)
 
 
@@ -998,7 +998,7 @@ if __name__ == '__main__':
     try:
         main(sys.argv[1:])
     except Fatal as e:
-        sys.stderr.write('\nERROR!\n%s\n\n' % (e,))
+        sys.stderr.write(colored('\nERROR!\n%s\n\n' % (e,), Fore.RED))
         sys.exit(125)
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -831,6 +831,14 @@ def main(args):
             action='count', default=0,
             help=quiet_help,
             )
+        parser.add_argument(
+            '--color', dest='color', action='store_true', default=True,
+            help='print status with colors',
+            )
+        parser.add_argument(
+            '--no-color', dest='color', action='store_false',
+            help='print status without colors',
+            )
 
     add_verbosity_options(parser, help=True)
 
@@ -1007,6 +1015,9 @@ def main(args):
     options = parser.parse_args(args)
 
     verbosity = options.verbose - options.quiet
+
+    if not (options.color and sys.stdout.isatty()):
+        AnsiColor.disable()
 
     # Expose the verbosity to child processes, in case they want to
     # adjust their output levels, too:

--- a/bin/git-test
+++ b/bin/git-test
@@ -580,7 +580,7 @@ def cmd_run(parser, options):
     test = Test(options.test)
 
     if verbosity >= 0:
-        sys.stderr.write('Using test %s; command: %s\n' % (test.name, test.command))
+        sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, Fore.YELLOW), colored(test.command, Fore.YELLOW)))
 
     try:
         require_clean_work_tree('test-run')


### PR DESCRIPTION
Add support for printing good/bad results with red/green colour coding so that it is easy to see the overall results at a quick glance rather than having to read and interpret the text.