### PR TITLE
Add a `list` subcommand

### DIFF
--- a/bin/git-test
+++ b/bin/git-test
@@ -799,8 +799,19 @@ def cmd_list(parser, options):
         m = test_re.match(key)
         if m:
             name = m.group('name')
+            command = value.rstrip()
+            command_lines = command.split('\n')
+
+            if not command_lines:
+                continue
+
             print('%s:' % (name,))
-            print('    command = %s' % (value,))
+            if len(command_lines) == 1:
+                print('    command = %s' % (command,))
+            else:
+                print('    command:')
+                for command_line in command_lines:
+                    print('        %s' % (command_line,))
 
 
 def cmd_remove(parser, options):

--- a/bin/git-test
+++ b/bin/git-test
@@ -788,6 +788,21 @@ def cmd_forget_results(parser, options):
             )
 
 
+test_re = re.compile(r'^test\.(?P<name>.*)\.command$')
+
+def cmd_list(parser, options):
+    cmd = ['git', 'config', '--get-regexp', '--null', '^test\.']
+    out = check_output(cmd)
+    lines = [line for line in out.split('\0') if line]
+    for line in lines:
+        (key, value) = line.split('\n', 1)
+        m = test_re.match(key)
+        if m:
+            name = m.group('name')
+            print('%s:' % (name,))
+            print('    command = %s' % (value,))
+
+
 def cmd_remove(parser, options):
     test = Test(options.test)
 
@@ -986,6 +1001,15 @@ def main(args):
     add_verbosity_options(subparser)
 
     subparser = subparsers.add_parser(
+        'list',
+        description=(
+            'List the tests that are currently defined.'
+            ),
+        help='list the tests that are currently defined',
+        )
+    add_verbosity_options(subparser)
+
+    subparser = subparsers.add_parser(
         'remove',
         description=(
             'Remove a test definition and all of its stored results.'
@@ -1044,6 +1068,8 @@ def main(args):
         cmd_results(parser, options)
     elif options.subcommand == 'forget-results':
         cmd_forget_results(parser, options)
+    elif options.subcommand == 'list':
+        cmd_list(parser, options)
     elif options.subcommand == 'remove':
         cmd_remove(parser, options)
     elif options.subcommand == 'help':


### PR DESCRIPTION
It's currently a pain to list all of the test commands that are available in a repository, so add a new `list` subcommand that lists them for you. Example:

```
$ git test list
default:
    command = make -j8 prove
failing:
    command = echo 'Gaaah!'; false
foo:
    command:
        echo Foooooo
        echo Baaaaaaaar
```
