### PR TITLE
Document environment variables exported + add a couple new

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ or
 
     git test run --help
 
+## Exposed environment variables
+
+`git test` exports some environment variables which can be used by test
+commands. See [this file](./env.md) for details.
 
 ## Best practice: use `git test` in a linked worktree
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -494,18 +494,26 @@ class Test(object):
         chatty_call(cmd)
         self._command = value
 
-    def run(self):
+    def run(self, extra_env={}):
         """Run this test against the current contents of the working tree."""
+
+        env = os.environ.copy()
+        if extra_env:
+            for k, v in extra_env.items():
+                if v is not None:
+                    env[k] = v
+                elif k in env:
+                    del env[k]
 
         cmd = ['sh', '-c', self.command]
         try:
-            chatty_call(cmd, level=0)
+            chatty_call(cmd, level=0, env=env)
         except CalledProcessError as e:
             raise UserTestError(e.returncode, e.cmd, e.output)
 
-    def run_and_record(self, revision):
+    def run_and_record(self, revision, extra_env={}):
         try:
-            self.run()
+            self.run(extra_env=extra_env)
         except UserTestError:
             sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('bad')))
             if verbosity >= -1:
@@ -655,7 +663,11 @@ def iter_commits(parser, options):
 
 def cmd_run(parser, options):
     test = Test(options.test)
-    os.environ['GIT_TEST_NAME'] = test.name
+    extra_env = {
+        'GIT_TEST_NAME' : test.name,
+        'GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT' : None,
+        'GIT_TEST_VERBOSITY' : str(verbosity),
+    }
 
     if verbosity >= 0:
         sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.CYAN), colored(test.command, AnsiColor.CYAN)))
@@ -669,7 +681,7 @@ def cmd_run(parser, options):
             raise
 
         try:
-            test.run()
+            test.run(extra_env=extra_env)
         except UserTestError as e:
             sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
             if verbosity >= -1:
@@ -713,7 +725,6 @@ def cmd_run(parser, options):
     fail_count = 0
     unknown_count = 0
 
-    os.environ['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = ''
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
@@ -752,7 +763,7 @@ def cmd_run(parser, options):
                 prepare_revision(r)
 
             try:
-                test.run_and_record(r)
+                test.run_and_record(r, extra_env=extra_env)
             except UserTestError as e:
                 # This commit has failed the test.
                 if options.keep_going:
@@ -760,7 +771,7 @@ def cmd_run(parser, options):
                     fail_count += 1
                 else:
                     sys.exit(e.returncode)
-            os.environ['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
+            extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
 
     if not testing_head:
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]

--- a/bin/git-test
+++ b/bin/git-test
@@ -713,6 +713,7 @@ def cmd_run(parser, options):
     fail_count = 0
     unknown_count = 0
 
+    os.environ['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = ''
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
@@ -759,6 +760,7 @@ def cmd_run(parser, options):
                     fail_count += 1
                 else:
                     sys.exit(e.returncode)
+            os.environ['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
 
     if not testing_head:
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]

--- a/bin/git-test
+++ b/bin/git-test
@@ -640,7 +640,7 @@ def iter_commits(parser, options):
         if len(limits) == 1:
             yield rev_parse('%s^{commit}' % (arg,))
         elif len(limits) == 2:
-            for revision in rev_list('--reverse', arg):
+            for revision in rev_list('--reverse', '--topo-order', arg):
                 yield revision
         else:
             parser.error(

--- a/bin/git-test
+++ b/bin/git-test
@@ -655,6 +655,7 @@ def iter_commits(parser, options):
 
 def cmd_run(parser, options):
     test = Test(options.test)
+    os.environ['GIT_TEST_NAME'] = test.name
 
     if verbosity >= 0:
         sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.CYAN), colored(test.command, AnsiColor.CYAN)))

--- a/env.md
+++ b/env.md
@@ -27,7 +27,7 @@ Example of using environment variables in a build script named `run-lint.sh`:
 ```shell
 #!/bin/sh
 
-if [ ${GIT_TEST_VERBOSITY:-0} -ge 1 ]
+if [ "${GIT_TEST_VERBOSITY:-0}" -ge 1 ]
 then
     if [ -f tslint.json ]
     then
@@ -37,9 +37,9 @@ then
     fi
 fi
 
-PARENT=`git log --pretty=%P -n 1 HEAD`
+PARENT=$(git log --pretty=%P -n 1 HEAD)
 # If current commit is not a merge commit ...
-if [ `echo $PARENT | wc -w` -eq 1 ]
+if [ "$(echo "$PARENT" | wc -w)" -eq 1 ]
 then
     if [ "$GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT" = "$PARENT" ]
     then

--- a/env.md
+++ b/env.md
@@ -6,6 +6,8 @@ be used if test are run through scripts.
 * `GIT_TEST_VERBOSITY` - Numeric value modified by `--verbose` (+1) and
   `--quiet` (-1), e.g. `--verbose --verbose --verbose --quiet` gives value 2.
 
+* `GIT_TEST_NAME` - Corresponds to the name of the current running test.
+
 # Example usage
 
 Example of using environment variables in a build script named `run-lint.sh`:
@@ -23,6 +25,7 @@ then
     fi
 fi
 
+git tag -f current-git-test-"$GIT_TEST_NAME"
 npm run lint
 ```
 
@@ -35,3 +38,20 @@ git test run --verbose --name=lint main..mybranch
 
 the script will output which lint tool that will be used for each commit it
 tests.
+
+---
+
+The tag `current-git-test-lint` will here be moved along as git-test checks out
+new commits. This means for instance that you can follow the progress by just
+refreshing your gitk window instead of having to check the output in a specific
+terminal window.
+
+If a test fails, the tag will be left on the last failing checked out commit,
+so you can easily fix it in the development worktree by running
+`rebase --interactive --rebase-merges current-git-test-lint^` for then to
+`edit` the commit and fix the issue.
+
+There is no "garbage collection" of such current test tags, so they will be
+left decaying if not actively cleaned up. So if this is a worthwile thing to do
+is completely up to you. But this is one example of what the `GIT_TEST_NAME`
+environment variable can be used for.

--- a/env.md
+++ b/env.md
@@ -1,0 +1,37 @@
+# Exposed environment variables
+
+`git test` exports the following environment variables which can for instance
+be used if test are run through scripts.
+
+* `GIT_TEST_VERBOSITY` - Numeric value modified by `--verbose` (+1) and
+  `--quiet` (-1), e.g. `--verbose --verbose --verbose --quiet` gives value 2.
+
+# Example usage
+
+Example of using environment variables in a build script named `run-lint.sh`:
+
+```shell
+#!/bin/sh
+
+if [ ${GIT_TEST_VERBOSITY:-0} -ge 1 ]
+then
+    if [ -f tslint.json ]
+    then
+        echo "Using tslint"
+    else
+        echo "Using eslint"
+    fi
+fi
+
+npm run lint
+```
+
+then when running
+
+```shell
+git test add --name=lint ./run-lint.sh
+git test run --verbose --name=lint main..mybranch
+```
+
+the script will output which lint tool that will be used for each commit it
+tests.

--- a/env.md
+++ b/env.md
@@ -10,6 +10,13 @@ be used if test are run through scripts.
 
 # Example usage
 
+Q: Wow, the following seems really complicated, do I really have to do all that
+just to run a test?
+
+A: Not at all. The following is more meant to be an example exploring
+everything than can be done with environment variables more than a template
+to be copied for everyone.
+
 Example of using environment variables in a build script named `run-lint.sh`:
 
 ```shell


### PR DESCRIPTION
Document the existing `GIT_TEST_VERBOSITY` and add two new `GIT_TEST_NAME` plus `GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT`.

I think the last one should be able to solve issue #13. Not automatically out of the box like requested, but it provides a framework to handle it (explicitly) in a more intelligent and optimal way than the alternative of just blindly doing it every single time.

On a fundamental level git submodules is a dependency external to the main repository (only a very special kind of dependency that is tightly integrated into git), but it really is not that different from other external dependencies like npm packages, ruby gems, python packages, etc whose used values can change from commit to commit. With `GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT` all such externally dependencies can be optimized to just update when needed.

And while the double if test for deciding to run `npm install` might look a bit gaudy, there is no need to inline it in every test. For all my typescript tests I just add a call to a script `./test-run-npm-install.sh` and that's it.
