### PR TITLE
stop test runner if working tree becomes dirty

### DIFF
--- a/bin/git-test
+++ b/bin/git-test
@@ -515,9 +515,21 @@ class Test(object):
                 sys.stderr.write(colored(FAIL_TRAILER_TEMPLATE % dict(), AnsiColor.RED))
                 self.write_status(revision, 'bad')
             raise
-        else:
-            sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('good')))
-            self.write_status(revision, 'good')
+
+        try:
+            require_clean_work_tree('mark good')
+        except UncleanWorkTreeError:
+            sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('bad')))
+            if verbosity >= -1:
+                sys.stderr.write(colored(FAIL_HEADER_TEMPLATE % dict(revision=revision), AnsiColor.RED))
+                cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
+                chatty_call(cmd, level=-1)
+                sys.stderr.write(colored(FAIL_TRAILER_TEMPLATE % dict(), AnsiColor.RED))
+                self.write_status(revision, 'bad')
+            raise
+
+        sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('good')))
+        self.write_status(revision, 'good')
 
     def remove_status(self, msg):
         """Delete the note reference for this test."""

--- a/test/run.t
+++ b/test/run.t
@@ -163,6 +163,15 @@ test_expect_success 'default (passing): combine args and stdin' '
 	test_cmp expected numbers.log
 '
 
+test_expect_success 'default (passing): stop if working tree is dirty' '
+	rm -f numbers.log &&
+	test_when_finished "git reset --hard HEAD" &&
+	git-test add --test dirty "echo 1 >> number" &&
+	gen_stdout c4 bad > expected-stdout &&
+	test_expect_code 125 git-test run --test dirty c3..c5 >actual-stdout &&
+	test_cmp expected-stdout actual-stdout
+'
+
 test_expect_success 'default (failing-4-7-8): test range' '
 	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 666 --good \*" &&


### PR DESCRIPTION
A command may leave the working tree dirty (e.g. the command is applying
code formatters to the tree).  In such a case, we should stop running
tests and allow the user to deal with it at the change that caused the
code to change.