### PR TITLE
Fix stacktraces (#21)

### DIFF
--- a/bin/git-test
+++ b/bin/git-test
@@ -530,7 +530,13 @@ class Test(object):
 
     def remove(self, msg):
         cmd = ['git', 'config', '--remove-section', 'test.%s' % (self.name,)]
-        chatty_call(cmd)
+        try:
+            chatty_call(cmd)
+        except CalledProcessError as e:
+            # No such section
+            if e.returncode == 128:
+                sys.exit(0)
+            raise CalledProcessError(e.returncode, e.cmd, _decode_output(e.output))
         self.remove_status(msg)
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -540,7 +540,15 @@ def iter_tests():
     """Iterate over all tests that are defined in the git configuration."""
 
     cmd = ['git', 'config', '--get-regexp', '--null', '^test\.']
-    out = check_output(cmd)
+    try:
+        out = check_output(cmd)
+    except CalledProcessError as e:
+        # No tests
+        if e.returncode == 1:
+            sys.exit(0)
+        else:
+            raise CalledProcessError(e.returncode, e.cmd, _decode_output(e.output))
+
     lines = [line for line in out.split('\0') if line]
 
     # A list of test names found (to preserve their order):
@@ -1130,5 +1138,3 @@ if __name__ == '__main__':
     except Fatal as e:
         sys.stderr.write(colored('\nERROR!\n%s\n\n' % (e,), AnsiColor.RED))
         sys.exit(125)
-
-


### PR DESCRIPTION
- `list`: output nothing if there are no tests
- `remove`: don’t raise an exception if there is no `default` to remove