### PR TITLE
Support running multiple tests per commit. e.g. `git test run -t build,lint,unittest main..mybranch`

### DIFF
--- a/bin/git-test
+++ b/bin/git-test
@@ -456,7 +456,7 @@ class Test(object):
             raise Fatal('fatal: error adding note to %s^{tree}' % (revision,))
         else:
             if verbosity >= 0:
-                sys.stderr.write('Marked tree %s^{tree} to be %s\n' % (revision, good_bad_text(value)))
+                sys.stderr.write('Marked tree %s^{tree} to be %s for test %s\n' % (revision, good_bad_text(value), colored(self.name, AnsiColor.CYAN)))
 
     def forget_status(self, revisions):
         """Forget the stored results (if any) for the specified revisions."""
@@ -742,19 +742,19 @@ def cmd_run(parser, options):
 
             if test.result.status == 'good':
                 sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
-                sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
+                sys.stderr.write('Tree %s^{tree} is already known to be %s for test %s.\n' % (rs, good_bad_text('good'), colored(test.name, AnsiColor.CYAN)))
 
             elif test.result.status == 'bad':
                 if options.retest and not options.dry_run:
                     sys.stderr.write(
-                        'Tree %s^{tree} was previously tested to be %s; retesting...\n'
-                        % (rs, good_bad_text('bad'))
+                        'Tree %s^{tree} was previously tested to be %s for test %s; retesting...\n'
+                        % (rs, good_bad_text('bad'), colored(test.name, AnsiColor.CYAN))
                         )
                     test.result.status = None
                     # fall through
                 else:
                     sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
-                    sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
+                    sys.stderr.write('Tree %s^{tree} is already known to be %s for test %s!\n' % (rs, good_bad_text('bad'), colored(test.name, AnsiColor.CYAN)))
                     test.result.status = 'failed'
                     if options.keep_going:
                         test.result.fail_count += 1
@@ -763,7 +763,7 @@ def cmd_run(parser, options):
 
             elif test.result.status == 'unknown':
                 if options.dry_run:
-                    sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
+                    sys.stdout.write('Tree %s^{tree} is %s for test %s\n' % (rs, good_bad_text('unknown'), colored(test.name, AnsiColor.CYAN)))
                     test.result.unknown_count += 1
                 else:
                     test.result.status = None

--- a/bin/git-test
+++ b/bin/git-test
@@ -670,15 +670,11 @@ def iter_commits(parser, options):
 
 
 def cmd_run(parser, options):
-    test = Test(options.test)
     extra_env = {
-        'GIT_TEST_NAME' : test.name,
         'GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT' : None,
         'GIT_TEST_VERBOSITY' : str(verbosity),
     }
-
-    if verbosity >= 0:
-        sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.CYAN), colored(test.command, AnsiColor.CYAN)))
+    tests = [Test(test_name) for test_name in options.test.split(',')]
 
     try:
         require_clean_work_tree('test-run')
@@ -689,7 +685,11 @@ def cmd_run(parser, options):
             raise
 
         try:
-            test.run(extra_env=extra_env)
+            for test in tests:
+                extra_env['GIT_TEST_NAME'] = test.name
+                if verbosity >= 0:
+                    sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.CYAN), colored(test.command, AnsiColor.CYAN)))
+                test.run(extra_env=extra_env)
         except UserTestError as e:
             sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
             if verbosity >= -1:
@@ -724,91 +724,97 @@ def cmd_run(parser, options):
         head = check_output(cmd).rstrip()
 
     if options.force or options.forget:
-        test.forget_status(revisions)
-
-        if options.forget:
-            return
+        for test in tests:
+            extra_env['GIT_TEST_NAME'] = test.name
+            if options.forget and verbosity >= 0:
+                sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.CYAN), colored(test.command, AnsiColor.CYAN)))
+            test.forget_status(revisions)
+            if options.forget:
+                return
 
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
-        test.result.status = test.read_status(r, rs)
+        for test in tests:
+            extra_env['GIT_TEST_NAME'] = test.name
 
-        if test.result.status == 'good':
-            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
-            sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
+            test.result.status = test.read_status(r, rs)
 
-        elif test.result.status == 'bad':
-            if options.retest and not options.dry_run:
-                sys.stderr.write(
-                    'Tree %s^{tree} was previously tested to be %s; retesting...\n'
-                    % (rs, good_bad_text('bad'))
-                    )
-                test.result.status = None
-                # fall through
-            else:
-                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
-                sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
-                test.result.status = 'failed'
-                if options.keep_going:
-                    test.result.fail_count += 1
+            if test.result.status == 'good':
+                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
+                sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
+
+            elif test.result.status == 'bad':
+                if options.retest and not options.dry_run:
+                    sys.stderr.write(
+                        'Tree %s^{tree} was previously tested to be %s; retesting...\n'
+                        % (rs, good_bad_text('bad'))
+                        )
+                    test.result.status = None
+                    # fall through
                 else:
-                    sys.exit(1)
+                    sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
+                    sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
+                    test.result.status = 'failed'
+                    if options.keep_going:
+                        test.result.fail_count += 1
+                    else:
+                        sys.exit(1)
 
-        elif test.result.status == 'unknown':
-            if options.dry_run:
-                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
-                test.result.unknown_count += 1
-            else:
-                test.result.status = None
-
-        if test.result.status is None:
-            if not testing_head:
-                prepare_revision(r)
-
-            try:
-                test.run_and_record(r, extra_env=extra_env)
-            except UserTestError as e:
-                # This commit has failed the test.
-                if options.keep_going:
-                    test.result.last_failure = e.returncode
-                    test.result.fail_count += 1
+            elif test.result.status == 'unknown':
+                if options.dry_run:
+                    sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
+                    test.result.unknown_count += 1
                 else:
-                    sys.exit(e.returncode)
-            extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
+                    test.result.status = None
+
+            if test.result.status is None:
+                if not testing_head:
+                    prepare_revision(r)
+
+                try:
+                    test.run_and_record(r, extra_env=extra_env)
+                except UserTestError as e:
+                    # This commit has failed the test.
+                    if options.keep_going:
+                        test.result.last_failure = e.returncode
+                        test.result.fail_count += 1
+                    else:
+                        sys.exit(e.returncode)
+                extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
 
     if not testing_head:
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
         chatty_call(cmd)
 
-    if test.result.fail_count > 0:
-        if verbosity >= -1:
-            if test.result.fail_count == 1:
-                test_text = 'TEST'
-            else:
-                test_text = 'TESTS'
-            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (test.result.fail_count, test_text), AnsiColor.RED))
+    for test in tests:
+        if test.result.fail_count > 0:
+            if verbosity >= -1:
+                if test.result.fail_count == 1:
+                    test_text = 'TEST'
+                else:
+                    test_text = 'TESTS'
+                sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (test.result.fail_count, test_text), AnsiColor.RED))
 
-        if test.result.last_failure is not None:
-            sys.exit(test.result.last_failure)
+            if test.result.last_failure is not None:
+                sys.exit(test.result.last_failure)
+            else:
+                sys.exit(1)
+        elif test.result.unknown_count > 0:
+            if verbosity >= -1:
+                if test.result.unknown_count == 1:
+                    test_text = 'TEST'
+                else:
+                    test_text = 'TESTS'
+                sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (test.result.unknown_count, test_text), AnsiColor.YELLOW))
+
+            sys.exit(2)
         else:
-            sys.exit(1)
-    elif test.result.unknown_count > 0:
-        if verbosity >= -1:
-            if test.result.unknown_count == 1:
-                test_text = 'TEST'
-            else:
-                test_text = 'TESTS'
-            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (test.result.unknown_count, test_text), AnsiColor.YELLOW))
-
-        sys.exit(2)
-    else:
-        if verbosity >= -1:
-            sys.stderr.write('\n%s %s %s\n' %
-                (colored('ALL', AnsiColor.GREEN),
-                colored(test.name, AnsiColor.CYAN),
-                colored('TESTS SUCCESSFUL', AnsiColor.GREEN)))
-        return
+            if verbosity >= -1:
+                sys.stderr.write('\n%s %s %s\n' %
+                    (colored('ALL', AnsiColor.GREEN),
+                    colored(test.name, AnsiColor.CYAN),
+                    colored('TESTS SUCCESSFUL', AnsiColor.GREEN)))
 
 
 def cmd_results(parser, options):

--- a/bin/git-test
+++ b/bin/git-test
@@ -800,7 +800,10 @@ def cmd_run(parser, options):
         sys.exit(2)
     else:
         if verbosity >= -1:
-            sys.stderr.write(colored('\nALL TESTS SUCCESSFUL\n', AnsiColor.GREEN))
+            sys.stderr.write('\n%s %s %s\n' %
+                (colored('ALL', AnsiColor.GREEN),
+                colored(test.name, AnsiColor.CYAN),
+                colored('TESTS SUCCESSFUL', AnsiColor.GREEN)))
         return
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -401,6 +401,13 @@ FAIL_TRAILER_TEMPLATE = """\
 FAILURE!
 """
 
+class TestResult:
+    def __init__(self):
+        self.last_failure = None
+        self.fail_count = 0
+        self.unknown_count = 0
+        self.status = None
+
 class Test(object):
     def __init__(self, name, _command=None):
         self.name = name
@@ -721,44 +728,42 @@ def cmd_run(parser, options):
         if options.forget:
             return
 
-    last_failure = None
-    fail_count = 0
-    unknown_count = 0
+    result = TestResult()
 
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
-        status = test.read_status(r, rs)
+        result.status = test.read_status(r, rs)
 
-        if status == 'good':
+        if result.status == 'good':
             sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
             sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
 
-        elif status == 'bad':
+        elif result.status == 'bad':
             if options.retest and not options.dry_run:
                 sys.stderr.write(
                     'Tree %s^{tree} was previously tested to be %s; retesting...\n'
                     % (rs, good_bad_text('bad'))
                     )
-                status = None
+                result.status = None
                 # fall through
             else:
                 sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
                 sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
-                status = 'failed'
+                result.status = 'failed'
                 if options.keep_going:
-                    fail_count += 1
+                    result.fail_count += 1
                 else:
                     sys.exit(1)
 
-        elif status == 'unknown':
+        elif result.status == 'unknown':
             if options.dry_run:
                 sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
-                unknown_count += 1
+                result.unknown_count += 1
             else:
-                status = None
+                result.status = None
 
-        if status is None:
+        if result.status is None:
             if not testing_head:
                 prepare_revision(r)
 
@@ -767,8 +772,8 @@ def cmd_run(parser, options):
             except UserTestError as e:
                 # This commit has failed the test.
                 if options.keep_going:
-                    last_failure = e.returncode
-                    fail_count += 1
+                    result.last_failure = e.returncode
+                    result.fail_count += 1
                 else:
                     sys.exit(e.returncode)
             extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
@@ -777,25 +782,25 @@ def cmd_run(parser, options):
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
         chatty_call(cmd)
 
-    if fail_count > 0:
+    if result.fail_count > 0:
         if verbosity >= -1:
-            if fail_count == 1:
+            if result.fail_count == 1:
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text), AnsiColor.RED))
+            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (result.fail_count, test_text), AnsiColor.RED))
 
-        if last_failure is not None:
-            sys.exit(last_failure)
+        if result.last_failure is not None:
+            sys.exit(result.last_failure)
         else:
             sys.exit(1)
-    elif unknown_count > 0:
+    elif result.unknown_count > 0:
         if verbosity >= -1:
-            if unknown_count == 1:
+            if result.unknown_count == 1:
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (unknown_count, test_text), AnsiColor.YELLOW))
+            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (result.unknown_count, test_text), AnsiColor.YELLOW))
 
         sys.exit(2)
     else:

--- a/bin/git-test
+++ b/bin/git-test
@@ -878,9 +878,10 @@ def cmd_list(parser, options):
 
 
 def cmd_remove(parser, options):
-    test = Test(options.test)
+    tests = [Test(test_name) for test_name in options.test.split(',')]
+    for test in tests:
 
-    test.remove('Test results deleted by \'git test remove\'')
+        test.remove('Test results deleted by \'git test remove\'')
 
 
 def cmd_help(parser, options, subparsers):

--- a/bin/git-test
+++ b/bin/git-test
@@ -414,6 +414,7 @@ class Test(object):
         self.notes_ref = 'tests/%s' % (self.name,)
         self.full_ref = 'refs/notes/tests/%s' % (self.name,)
         self._command = _command
+        self.result = TestResult()
 
     def initialize_status(self, msg):
         cmd = ['git', 'commit-tree', '-m', msg, get_empty_tree()]
@@ -728,42 +729,40 @@ def cmd_run(parser, options):
         if options.forget:
             return
 
-    result = TestResult()
-
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
-        result.status = test.read_status(r, rs)
+        test.result.status = test.read_status(r, rs)
 
-        if result.status == 'good':
+        if test.result.status == 'good':
             sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
             sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
 
-        elif result.status == 'bad':
+        elif test.result.status == 'bad':
             if options.retest and not options.dry_run:
                 sys.stderr.write(
                     'Tree %s^{tree} was previously tested to be %s; retesting...\n'
                     % (rs, good_bad_text('bad'))
                     )
-                result.status = None
+                test.result.status = None
                 # fall through
             else:
                 sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
                 sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
-                result.status = 'failed'
+                test.result.status = 'failed'
                 if options.keep_going:
-                    result.fail_count += 1
+                    test.result.fail_count += 1
                 else:
                     sys.exit(1)
 
-        elif result.status == 'unknown':
+        elif test.result.status == 'unknown':
             if options.dry_run:
                 sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
-                result.unknown_count += 1
+                test.result.unknown_count += 1
             else:
-                result.status = None
+                test.result.status = None
 
-        if result.status is None:
+        if test.result.status is None:
             if not testing_head:
                 prepare_revision(r)
 
@@ -772,8 +771,8 @@ def cmd_run(parser, options):
             except UserTestError as e:
                 # This commit has failed the test.
                 if options.keep_going:
-                    result.last_failure = e.returncode
-                    result.fail_count += 1
+                    test.result.last_failure = e.returncode
+                    test.result.fail_count += 1
                 else:
                     sys.exit(e.returncode)
             extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
@@ -782,25 +781,25 @@ def cmd_run(parser, options):
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
         chatty_call(cmd)
 
-    if result.fail_count > 0:
+    if test.result.fail_count > 0:
         if verbosity >= -1:
-            if result.fail_count == 1:
+            if test.result.fail_count == 1:
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (result.fail_count, test_text), AnsiColor.RED))
+            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (test.result.fail_count, test_text), AnsiColor.RED))
 
-        if result.last_failure is not None:
-            sys.exit(result.last_failure)
+        if test.result.last_failure is not None:
+            sys.exit(test.result.last_failure)
         else:
             sys.exit(1)
-    elif result.unknown_count > 0:
+    elif test.result.unknown_count > 0:
         if verbosity >= -1:
-            if result.unknown_count == 1:
+            if test.result.unknown_count == 1:
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (result.unknown_count, test_text), AnsiColor.YELLOW))
+            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (test.result.unknown_count, test_text), AnsiColor.YELLOW))
 
         sys.exit(2)
     else:

--- a/bin/git-test
+++ b/bin/git-test
@@ -839,18 +839,19 @@ def cmd_results(parser, options):
 
 
 def cmd_forget_results(parser, options):
-    test = Test(options.test)
+    tests = [Test(test_name) for test_name in options.test.split(',')]
+    for test in tests:
 
-    cmd = ['git', 'config', 'test.%s.command' % (test.name,)]
-    try:
-        chatty_call(cmd)
-    except CalledProcessError:
-        # There is no test defined; simply delete the notes reference:
-        test.remove_status('Test results deleted by \'git test forget-results\'')
-    else:
-        test.initialize_status(
-            'Test results reinitialized by \'git test forget-results\''
-            )
+        cmd = ['git', 'config', 'test.%s.command' % (test.name,)]
+        try:
+            chatty_call(cmd)
+        except CalledProcessError:
+            # There is no test defined; simply delete the notes reference:
+            test.remove_status('Test results deleted by \'git test forget-results\'')
+        else:
+            test.initialize_status(
+                'Test results reinitialized by \'git test forget-results\''
+                )
 
 
 test_re = re.compile(r'^test\.(?P<name>.*)\.command$')


### PR DESCRIPTION
These are changes I have been using locally for a long time, and would like to have applied upstream.

It resolves the majority of issue #12.

Commit *"Add support for running multiple tests for each commit"* is best reviewed with ignore space changes since it changes indentation level with `for test in tests:` for several lines.
