### PR TITLE
Support running multiple tests per commit

### DIFF
--- a/bin/git-test
+++ b/bin/git-test
@@ -953,10 +953,9 @@ def cmd_run(parser, options):
 
 
 def cmd_results(parser, options):
-    test = Test(options.test)
+    tests = [Test(test_name) for test_name in options.tests]
 
     revisions = list(uniqify(iter_commits(parser, options)))
-
     if not revisions:
         sys.stderr.write('NO COMMITS SPECIFIED! (so none failed)\n')
         return
@@ -964,25 +963,27 @@ def cmd_results(parser, options):
         revisions = [rev_parse('HEAD')]
 
     for r in revisions:
-        status = test.read_status(r)
-        if status == 'good':
-            sys.stdout.write(
-                '%s^{tree} %s (%s:%s)\n' % (
-                    r, good_bad_text('good'), test.name, good_bad_text('known-good'),
-                ),
-            )
-        elif status == 'bad':
-            sys.stdout.write(
-                '%s^{tree} %s (%s:%s)\n' % (
-                    r, good_bad_text('bad'), test.name, good_bad_text('known-bad'),
-                ),
-            )
-        elif status == 'unknown':
-            sys.stdout.write(
-                '%s^{tree} %s (%s:%s)\n' % (
-                    r, good_bad_text('unknown'), test.name, good_bad_text('unknown'),
-                ),
-            )
+        overall_status = 'good'
+        per_test_status = []
+        for test in tests:
+            status = test.read_status(r)
+            if status == 'good':
+                per_test_status.append('%s:%s' % (AnsiColor.CYAN(test.name), AnsiColor.GREEN(status)))
+            elif status == 'bad':
+                per_test_status.append('%s:%s' % (AnsiColor.CYAN(test.name), AnsiColor.RED(status)))
+                overall_status = 'bad'
+            elif status == 'unknown':
+                per_test_status.append('%s:%s' % (AnsiColor.CYAN(test.name), AnsiColor.YELLOW(status)))
+                if overall_status == 'good':
+                    overall_status = 'unknown'
+
+        per_test_status = ' '.join(per_test_status)
+
+        sys.stdout.write(
+            '%s^{tree} %s (%s)\n' % (
+                r, good_bad_text(overall_status), per_test_status,
+            ),
+        )
 
 
 def cmd_forget_results(parser, options):
@@ -1195,9 +1196,10 @@ def main(args):
         help='show any stored test results for the specified commits',
         )
     subparser.add_argument(
-        '--test', '-t', metavar='name',
-        action='store', default='default',
-        help='name of test (default is \'default\')',
+        '--test', '--tests', '-t', metavar='name',
+        action='store', dest='tests',
+        type=csv, default=['default'],
+        help='comma-separated name(s) of test(s) (default is \'default\')',
         )
     subparser.add_argument(
         '--stdin', action='store_true',

--- a/bin/git-test
+++ b/bin/git-test
@@ -658,12 +658,20 @@ def run_in_dirty_tree(test, extra_env, options):
     try:
         test.run(extra_env=extra_env)
     except UserTestError as e:
-        sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
+        sys.stdout.write(
+            'working-tree %s (%s:%s)\n' % (
+                good_bad_text('bad'), test.name, good_bad_text('bad'),
+            ),
+        )
         if verbosity >= -1:
             sys.stderr.write(AnsiColor.RED('\n!!! TEST FAILED !!!\n'))
         sys.exit(e.returncode)
     else:
-        sys.stdout.write('working-tree %s\n' % good_bad_text('good'))
+        sys.stdout.write(
+            'working-tree %s (%s:%s)\n' % (
+                good_bad_text('good'), test.name, good_bad_text('good'),
+            ),
+        )
         if verbosity >= -1:
             sys.stderr.write(AnsiColor.GREEN('\nTEST SUCCESSFUL\n'))
     finally:
@@ -728,7 +736,11 @@ def cmd_run(parser, options):
         status = test.read_status(r, rs)
 
         if status == 'good':
-            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
+            sys.stdout.write(
+                '%s^{tree} %s (%s:%s)\n' % (
+                    r, good_bad_text('good'), test.name, good_bad_text('known-good'),
+                ),
+            )
             sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
 
         elif status == 'bad':
@@ -740,7 +752,11 @@ def cmd_run(parser, options):
                 status = None
                 # fall through
             else:
-                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
+                sys.stdout.write(
+                    '%s^{tree} %s (%s:%s)\n' % (
+                        r, good_bad_text('bad'), test.name, good_bad_text('known-bad'),
+                    ),
+                )
                 sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
                 status = 'failed'
                 if options.keep_going:
@@ -750,7 +766,11 @@ def cmd_run(parser, options):
 
         elif status == 'unknown':
             if options.dry_run:
-                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
+                sys.stdout.write(
+                    '%s^{tree} %s (%s:%s)\n' % (
+                        r, good_bad_text('unknown'), test.name, good_bad_text('unknown'),
+                    ),
+                )
                 unknown_count += 1
             else:
                 status = None
@@ -763,7 +783,11 @@ def cmd_run(parser, options):
                 test.run(extra_env=extra_env)
             except UserTestError as e:
                 # This commit has failed the test.
-                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('bad')))
+                sys.stdout.write(
+                    '%s^{tree} %s (%s:%s)\n' % (
+                        r, good_bad_text('bad'), test.name, good_bad_text('bad'),
+                    ),
+                )
                 if verbosity >= -1:
                     sys.stderr.write(AnsiColor.RED(FAIL_HEADER_TEMPLATE % dict(revision=r)))
                     cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
@@ -777,7 +801,11 @@ def cmd_run(parser, options):
                 else:
                     sys.exit(e.returncode)
             else:
-                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('good')))
+                sys.stdout.write(
+                    '%s^{tree} %s (%s:%s)\n' % (
+                        r, good_bad_text('good'), test.name, good_bad_text('good'),
+                    ),
+                )
                 test.write_status(r, 'good')
 
             extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
@@ -827,11 +855,23 @@ def cmd_results(parser, options):
     for r in revisions:
         status = test.read_status(r)
         if status == 'good':
-            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-good')))
+            sys.stdout.write(
+                '%s^{tree} %s (%s:%s)\n' % (
+                    r, good_bad_text('good'), test.name, good_bad_text('known-good'),
+                ),
+            )
         elif status == 'bad':
-            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('known-bad')))
+            sys.stdout.write(
+                '%s^{tree} %s (%s:%s)\n' % (
+                    r, good_bad_text('bad'), test.name, good_bad_text('known-bad'),
+                ),
+            )
         elif status == 'unknown':
-            sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('unknown')))
+            sys.stdout.write(
+                '%s^{tree} %s (%s:%s)\n' % (
+                    r, good_bad_text('unknown'), test.name, good_bad_text('unknown'),
+                ),
+            )
 
 
 def cmd_forget_results(parser, options):

--- a/bin/git-test
+++ b/bin/git-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; coding: utf-8 -*-
 
 # Copyright (c) 2013-2016 Michael Haggerty

--- a/bin/git-test
+++ b/bin/git-test
@@ -400,7 +400,7 @@ def require_clean_work_tree(action):
 FAIL_HEADER_TEMPLATE = """\
 
 *******************************************************************************
-FAILED ON COMMIT %(revision)s
+BAD COMMIT %(revision)s: (%(tests)s)
 
 """
 
@@ -660,54 +660,86 @@ def iter_commits(parser, options):
             yield rev_parse('%s^{commit}' % (arg.strip(),))
 
 
-def run_in_dirty_tree(test, extra_env, options):
+def run_in_dirty_tree(tests, extra_env, options):
+    fail_count = 0
+
     try:
-        test.run(extra_env=extra_env)
-    except UserTestError as e:
-        sys.stdout.write(
-            'working-tree %s (%s:%s)\n' % (
-                good_bad_text('bad'), test.name, good_bad_text('bad'),
-            ),
-        )
-        if verbosity >= -1:
-            sys.stderr.write(
-                '\n%s\n' % (
-                    AnsiColor.RED('!!! TEST \'%s\' FAILED !!!' % (test.name,)),
-                ),
-            )
-        sys.exit(e.returncode)
-    else:
-        sys.stdout.write(
-            'working-tree %s (%s:%s)\n' % (
-                good_bad_text('good'), test.name, good_bad_text('good'),
-            ),
-        )
-        if verbosity >= -1:
-            sys.stderr.write(
-                '\n%s\n' % (
-                    AnsiColor.GREEN('TEST \'%s\' SUCCESSFUL' % (test.name,)),
-                ),
-            )
+        for test in tests:
+            extra_env['GIT_TEST_NAME'] = test.name
+            if verbosity >= 0:
+                sys.stderr.write(
+                    'Using test %s; command: %s\n' % (
+                        AnsiColor.CYAN(test.name),
+                        AnsiColor.CYAN(test.command),
+                    ),
+                )
+
+            try:
+                test.run(extra_env=extra_env)
+            except UserTestError as e:
+                sys.stdout.write(
+                    'working-tree %s (%s:%s)\n' % (
+                        good_bad_text('bad'), test.name, good_bad_text('bad'),
+                    ),
+                )
+                if verbosity >= -1:
+                    sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.RED('!!! TEST \'%s\' FAILED !!!' % (test.name,)),
+                        ),
+                    )
+                fail_count += 1
+                if not options.keep_going:
+                    sys.exit(e.returncode)
+            else:
+                sys.stdout.write(
+                    'working-tree %s (%s:%s)\n' % (
+                        good_bad_text('good'), test.name, good_bad_text('good'),
+                    ),
+                )
+                if verbosity >= -1:
+                    sys.stderr.write(
+                        '\n%s\n' % (
+                            AnsiColor.GREEN('TEST \'%s\' SUCCESSFUL' % (test.name,)),
+                        ),
+                    )
     finally:
+        if len(tests) == 1:
+            # No need for a summary.
+            pass
+        elif fail_count > 0:
+            if verbosity >= -1:
+                if fail_count == 1:
+                    test_text = 'TEST'
+                else:
+                    test_text = 'TESTS'
+
+                sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.RED('!!! %s %s FAILED !!!' % (fail_count, test_text)),
+                    ),
+                )
+
+            sys.exit(1)
+        else:
+            if verbosity >= -1:
+                sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.GREEN('ALL TESTS SUCCESSFUL'),
+                    ),
+                )
+
         sys.stderr.write(
             'Note: working tree is dirty; results will not be saved.\n'
             )
 
 
 def cmd_run(parser, options):
-    test = Test(options.test)
     extra_env = {
-        'GIT_TEST_NAME' : test.name,
         'GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT' : None,
         'GIT_TEST_VERBOSITY' : str(verbosity),
     }
-
-    if verbosity >= 0:
-        sys.stderr.write(
-            'Using test \'%s\'; command: %s\n' % (
-                AnsiColor.CYAN(test.name), AnsiColor.CYAN(test.command),
-            ),
-        )
+    tests = [Test(test_name) for test_name in options.tests]
 
     try:
         require_clean_work_tree('test-run')
@@ -717,7 +749,7 @@ def cmd_run(parser, options):
         if options.commits or options.stdin or options.forget or options.dry_run:
             raise
 
-        run_in_dirty_tree(test, extra_env, options)
+        run_in_dirty_tree(tests, extra_env, options)
         return
 
     revisions = list(uniqify(iter_commits(parser, options)))
@@ -739,147 +771,186 @@ def cmd_run(parser, options):
         head = check_output(cmd).rstrip()
 
     if options.force or options.forget:
-        test.forget_status(revisions)
-
+        for test in tests:
+            if options.forget and verbosity >= 0:
+                sys.stderr.write(
+                    'Using test \'%s\'; command: %s\n' % (
+                        AnsiColor.CYAN(test.name), AnsiColor.CYAN(test.command),
+                    ),
+                )
+            test.forget_status(revisions)
         if options.forget:
             return
 
-    last_failure = None
     fail_count = 0
     unknown_count = 0
-
+    last_failure = None
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
-        status = test.read_status(r, rs)
+        prepared = False
+        failed_tests = []
+        for test in tests:
+            extra_env['GIT_TEST_NAME'] = test.name
 
-        if status == 'good':
-            sys.stdout.write(
-                '%s^{tree} %s (%s:%s)\n' % (
-                    r, good_bad_text('good'), test.name, good_bad_text('known-good'),
-                ),
-            )
-            sys.stderr.write(
-                'Tree %s^{tree} is already known to be %s for test \'%s\'.\n' % (
-                    rs, good_bad_text('good'), test.name,
-                ),
-            )
+            status = test.read_status(r, rs)
 
-        elif status == 'bad':
-            if options.retest and not options.dry_run:
-                sys.stderr.write(
-                    'Tree %s^{tree} was previously tested to be %s for test \'%s\'; retesting...\n' % (
-                        rs, good_bad_text('bad'), test.name,
-                    ),
-                )
-                status = None
-                # fall through
-            else:
+            if status == 'good':
                 sys.stdout.write(
                     '%s^{tree} %s (%s:%s)\n' % (
-                        r, good_bad_text('bad'), test.name, good_bad_text('known-bad'),
+                        r, good_bad_text('good'), test.name, good_bad_text('known-good'),
                     ),
                 )
                 sys.stderr.write(
-                    'Tree %s^{tree} is already known to be %s for test \'%s\'!\n' % (
-                        rs, good_bad_text('bad'), test.name,
+                    'Tree %s^{tree} is already known to be %s for test \'%s\'.\n' % (
+                        rs, good_bad_text('good'), test.name,
                     ),
                 )
-                status = 'failed'
-                if options.keep_going:
-                    fail_count += 1
+
+            elif status == 'bad':
+                if options.retest and not options.dry_run:
+                    sys.stderr.write(
+                        'Tree %s^{tree} was previously tested to be %s for test \'%s\'; retesting...\n' % (
+                            rs, good_bad_text('bad'), test.name,
+                        ),
+                        )
+                    status = None
+                    # fall through
                 else:
-                    sys.exit(1)
+                    sys.stdout.write(
+                        '%s^{tree} %s (%s:%s)\n' % (
+                            r, good_bad_text('bad'), test.name, good_bad_text('known-bad'),
+                        ),
+                    )
+                    sys.stderr.write(
+                        'Tree %s^{tree} is already known to be %s for test \'%s\'!\n' % (
+                            rs, good_bad_text('bad'), test.name,
+                        ),
+                    )
+                    failed_tests.append('%s:known-bad' % (test.name,))
+                    fail_count += 1
+                    status = 'failed'
+                    if not options.keep_going:
+                        sys.exit(1)
 
-        elif status == 'unknown':
-            if options.dry_run:
-                sys.stdout.write(
-                    '%s^{tree} %s (%s:%s)\n' % (
-                        r, good_bad_text('unknown'), test.name, good_bad_text('unknown'),
-                    ),
-                )
-                unknown_count += 1
-            else:
-                status = None
+            elif status == 'unknown':
+                if options.dry_run:
+                    sys.stdout.write(
+                        '%s^{tree} %s (%s:%s)\n' % (
+                            r, good_bad_text('unknown'), test.name, good_bad_text('unknown'),
+                        ),
+                    )
+                    unknown_count += 1
+                else:
+                    status = None
 
-        if status is None:
-            if not testing_head:
-                prepare_revision(r)
+            if status is None:
+                if not testing_head and not prepared:
+                    prepare_revision(r)
+                    prepared = True
 
-            try:
-                test.run(extra_env=extra_env)
-            except UserTestError as e:
-                # This commit has failed the test.
-                sys.stdout.write(
-                    '%s^{tree} %s (%s:%s)\n' % (
-                        r, good_bad_text('bad'), test.name, good_bad_text('bad'),
-                    ),
-                )
-                if verbosity >= -1:
-                    sys.stderr.write(AnsiColor.RED(FAIL_HEADER_TEMPLATE % dict(revision=r)))
-                    cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
-                    chatty_call(cmd, level=-1)
-                    sys.stderr.write(AnsiColor.RED(FAIL_TRAILER_TEMPLATE % dict()))
+                try:
+                    test.run(extra_env=extra_env)
+                except UserTestError as e:
+                    # This commit has failed the test.
+                    sys.stdout.write(
+                        '%s^{tree} %s (%s:%s)\n' % (
+                            r, good_bad_text('bad'), test.name, good_bad_text('bad'),
+                        ),
+                    )
+
                     test.write_status(r, 'bad')
 
-                if options.keep_going:
-                    last_failure = e.returncode
+                    failed_tests.append('%s:bad' % (test.name,))
                     fail_count += 1
-                else:
-                    sys.exit(e.returncode)
-            else:
-                sys.stdout.write(
-                    '%s^{tree} %s (%s:%s)\n' % (
-                        r, good_bad_text('good'), test.name, good_bad_text('good'),
-                    ),
-                )
-                test.write_status(r, 'good')
+                    last_failure = e.returncode
 
-            extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
+                    if not options.keep_going:
+                        if verbosity >= -1:
+                            sys.stderr.write(
+                                AnsiColor.RED(
+                                    FAIL_HEADER_TEMPLATE % dict(
+                                        revision=r,
+                                        tests=','.join(failed_tests),
+                                    ),
+                                ),
+                            )
+                            cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
+                            chatty_call(cmd, level=-1)
+                            sys.stderr.write(AnsiColor.RED(FAIL_TRAILER_TEMPLATE % dict()))
+
+                        sys.exit(e.returncode)
+                else:
+                    sys.stdout.write(
+                        '%s^{tree} %s (%s:%s)\n' % (
+                            r, good_bad_text('good'), test.name, good_bad_text('good'),
+                        ),
+                    )
+                    test.write_status(r, 'good')
+
+                extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
+
+        if failed_tests and verbosity >= -1:
+            sys.stderr.write(
+                AnsiColor.RED(
+                    FAIL_HEADER_TEMPLATE % dict(
+                        revision=r,
+                        tests=','.join(failed_tests),
+                    ),
+                ),
+            )
+            cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
+            chatty_call(cmd, level=-1)
+            sys.stderr.write(AnsiColor.RED(FAIL_TRAILER_TEMPLATE % dict()))
 
     if not testing_head:
         cmd = ['git', 'checkout', '-f', re.sub(r'^refs/heads/', '', head)]
         chatty_call(cmd)
 
-    if fail_count > 0:
-        if verbosity >= -1:
+    if verbosity >= -1:
+        # Write out an overall summary (number of tests failed/unknown):
+        if fail_count > 0:
             if fail_count == 1:
-                test_text = 'TEST'
+                sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.RED('!!! %s TEST FAILED !!!' % (fail_count,)),
+                    ),
+                )
             else:
-                test_text = 'TESTS'
-            sys.stderr.write(
-                '\n%s: %s\n' % (
-                    AnsiColor.RED('!!! %s %s FAILED !!!' % (fail_count, test_text)),
-                    AnsiColor.CYAN(test.name),
-                ),
-            )
+                sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.RED('!!! %s TESTS FAILED !!!' % (fail_count,)),
+                    ),
+                )
 
-        if last_failure is not None:
-            sys.exit(last_failure)
-        else:
-            sys.exit(1)
-    elif unknown_count > 0:
-        if verbosity >= -1:
+        if unknown_count > 0:
             if unknown_count == 1:
-                test_text = 'TEST'
+                sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.YELLOW('%s TEST UNKNOWN' % (unknown_count,)),
+                    ),
+                )
             else:
-                test_text = 'TESTS'
-            sys.stderr.write(
-                '\n%s: %s\n' % (
-                    AnsiColor.YELLOW('%s %s UNKNOWN' % (unknown_count, test_text)),
-                    AnsiColor.CYAN(test.name),
-                ),
-            )
+                sys.stderr.write(
+                    '\n%s\n' % (
+                        AnsiColor.YELLOW('%s TESTS UNKNOWN' % (unknown_count,)),
+                    ),
+                )
 
-        sys.exit(2)
-    else:
-        if verbosity >= -1:
+        if fail_count == 0 and unknown_count == 0:
             sys.stderr.write(
                 '\n%s\n' % (
                     AnsiColor.GREEN('ALL TESTS SUCCESSFUL'),
                 ),
             )
-        return
+
+    if fail_count > 0:
+        if last_failure is not None:
+            sys.exit(last_failure)
+        else:
+            sys.exit(1)
+    elif unknown_count > 0:
+        sys.exit(2)
 
 
 def cmd_results(parser, options):
@@ -972,6 +1043,10 @@ def cmd_help(parser, options, subparsers):
     parser.exit()
 
 
+def csv(s):
+    return s.split(',')
+
+
 def main(args):
     global verbosity
 
@@ -1043,9 +1118,10 @@ def main(args):
 
     def add_run_arguments(subparser):
         subparser.add_argument(
-            '--test', '-t', metavar='name',
-            action='store', default='default',
-            help='name of test (default is \'default\')',
+            '--test', '--tests', '-t', metavar='name',
+            action='store', dest='tests',
+            type=csv, default=['default'],
+            help='comma-separated name(s) of test(s) (default is \'default\')',
             )
         subparser.add_argument(
             '--force', '-f', action='store_true',

--- a/bin/git-test
+++ b/bin/git-test
@@ -457,7 +457,11 @@ class Test(object):
             raise Fatal('fatal: error adding note to %s^{tree}' % (revision,))
         else:
             if verbosity >= 0:
-                sys.stderr.write('Marked tree %s^{tree} to be %s\n' % (revision, good_bad_text(value)))
+                sys.stderr.write(
+                    'Marked tree %s^{tree} to be %s for test \'%s\'\n' % (
+                        revision, good_bad_text(value), self.name,
+                    ),
+                )
 
     def forget_status(self, revisions):
         """Forget the stored results (if any) for the specified revisions."""
@@ -620,7 +624,9 @@ def cmd_add(parser, options):
                 # results and the user didn't explicitly ask for
                 # `--keep`; emit a warning in case the user forgot to
                 # `--forget`:
-                sys.stderr.write(AnsiColor.CYAN(REUSE_RESULTS_WARNING % dict(name=test.name)))
+                sys.stderr.write(
+                    AnsiColor.CYAN(REUSE_RESULTS_WARNING % dict(name=test.name)),
+                )
 
     if initialize:
         test.initialize_status('Test results initialized by \'git test add\'')
@@ -664,7 +670,11 @@ def run_in_dirty_tree(test, extra_env, options):
             ),
         )
         if verbosity >= -1:
-            sys.stderr.write(AnsiColor.RED('\n!!! TEST FAILED !!!\n'))
+            sys.stderr.write(
+                '\n%s\n' % (
+                    AnsiColor.RED('!!! TEST \'%s\' FAILED !!!' % (test.name,)),
+                ),
+            )
         sys.exit(e.returncode)
     else:
         sys.stdout.write(
@@ -673,7 +683,11 @@ def run_in_dirty_tree(test, extra_env, options):
             ),
         )
         if verbosity >= -1:
-            sys.stderr.write(AnsiColor.GREEN('\nTEST SUCCESSFUL\n'))
+            sys.stderr.write(
+                '\n%s\n' % (
+                    AnsiColor.GREEN('TEST \'%s\' SUCCESSFUL' % (test.name,)),
+                ),
+            )
     finally:
         sys.stderr.write(
             'Note: working tree is dirty; results will not be saved.\n'
@@ -689,7 +703,11 @@ def cmd_run(parser, options):
     }
 
     if verbosity >= 0:
-        sys.stderr.write('Using test %s; command: %s\n' % (AnsiColor.CYAN(test.name), AnsiColor.CYAN(test.command)))
+        sys.stderr.write(
+            'Using test \'%s\'; command: %s\n' % (
+                AnsiColor.CYAN(test.name), AnsiColor.CYAN(test.command),
+            ),
+        )
 
     try:
         require_clean_work_tree('test-run')
@@ -741,14 +759,19 @@ def cmd_run(parser, options):
                     r, good_bad_text('good'), test.name, good_bad_text('known-good'),
                 ),
             )
-            sys.stderr.write('Tree %s^{tree} is already known to be %s.\n' % (rs, good_bad_text('good')))
+            sys.stderr.write(
+                'Tree %s^{tree} is already known to be %s for test \'%s\'.\n' % (
+                    rs, good_bad_text('good'), test.name,
+                ),
+            )
 
         elif status == 'bad':
             if options.retest and not options.dry_run:
                 sys.stderr.write(
-                    'Tree %s^{tree} was previously tested to be %s; retesting...\n'
-                    % (rs, good_bad_text('bad'))
-                    )
+                    'Tree %s^{tree} was previously tested to be %s for test \'%s\'; retesting...\n' % (
+                        rs, good_bad_text('bad'), test.name,
+                    ),
+                )
                 status = None
                 # fall through
             else:
@@ -757,7 +780,11 @@ def cmd_run(parser, options):
                         r, good_bad_text('bad'), test.name, good_bad_text('known-bad'),
                     ),
                 )
-                sys.stderr.write('Tree %s^{tree} is already known to be %s!\n' % (rs, good_bad_text('bad')))
+                sys.stderr.write(
+                    'Tree %s^{tree} is already known to be %s for test \'%s\'!\n' % (
+                        rs, good_bad_text('bad'), test.name,
+                    ),
+                )
                 status = 'failed'
                 if options.keep_going:
                     fail_count += 1
@@ -820,7 +847,12 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(AnsiColor.RED('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text)))
+            sys.stderr.write(
+                '\n%s: %s\n' % (
+                    AnsiColor.RED('!!! %s %s FAILED !!!' % (fail_count, test_text)),
+                    AnsiColor.CYAN(test.name),
+                ),
+            )
 
         if last_failure is not None:
             sys.exit(last_failure)
@@ -832,12 +864,21 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(AnsiColor.YELLOW('\n%s %s UNKNOWN\n' % (unknown_count, test_text)))
+            sys.stderr.write(
+                '\n%s: %s\n' % (
+                    AnsiColor.YELLOW('%s %s UNKNOWN' % (unknown_count, test_text)),
+                    AnsiColor.CYAN(test.name),
+                ),
+            )
 
         sys.exit(2)
     else:
         if verbosity >= -1:
-            sys.stderr.write(AnsiColor.GREEN('\nALL TESTS SUCCESSFUL\n'))
+            sys.stderr.write(
+                '\n%s\n' % (
+                    AnsiColor.GREEN('ALL TESTS SUCCESSFUL'),
+                ),
+            )
         return
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -520,22 +520,6 @@ class Test(object):
         except CalledProcessError as e:
             raise UserTestError(e.returncode, e.cmd, e.output)
 
-    def run_and_record(self, revision, extra_env={}):
-        try:
-            self.run(extra_env=extra_env)
-        except UserTestError:
-            sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('bad')))
-            if verbosity >= -1:
-                sys.stderr.write(AnsiColor.RED(FAIL_HEADER_TEMPLATE % dict(revision=revision)))
-                cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
-                chatty_call(cmd, level=-1)
-                sys.stderr.write(AnsiColor.RED(FAIL_TRAILER_TEMPLATE % dict()))
-                self.write_status(revision, 'bad')
-            raise
-        else:
-            sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('good')))
-            self.write_status(revision, 'good')
-
     def remove_status(self, msg):
         """Delete the note reference for this test."""
 
@@ -776,14 +760,26 @@ def cmd_run(parser, options):
                 prepare_revision(r)
 
             try:
-                test.run_and_record(r, extra_env=extra_env)
+                test.run(extra_env=extra_env)
             except UserTestError as e:
                 # This commit has failed the test.
+                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('bad')))
+                if verbosity >= -1:
+                    sys.stderr.write(AnsiColor.RED(FAIL_HEADER_TEMPLATE % dict(revision=r)))
+                    cmd = ['git', '--no-pager', 'log', '-1', '--decorate', r]
+                    chatty_call(cmd, level=-1)
+                    sys.stderr.write(AnsiColor.RED(FAIL_TRAILER_TEMPLATE % dict()))
+                    test.write_status(r, 'bad')
+
                 if options.keep_going:
                     last_failure = e.returncode
                     fail_count += 1
                 else:
                     sys.exit(e.returncode)
+            else:
+                sys.stdout.write('%s^{tree} %s\n' % (r, good_bad_text('good')))
+                test.write_status(r, 'good')
+
             extra_env['GIT_TEST_PREVIOUS_CHECKED_OUT_COMMIT'] = r
 
     if not testing_head:

--- a/bin/git-test
+++ b/bin/git-test
@@ -1024,9 +1024,9 @@ def cmd_list(parser, options):
 
 
 def cmd_remove(parser, options):
-    test = Test(options.test)
-
-    test.remove('Test results deleted by \'git test remove\'')
+    tests = [Test(test_name) for test_name in options.tests]
+    for test in tests:
+        test.remove('Test results deleted by \'git test remove\'')
 
 
 def cmd_help(parser, options, subparsers):
@@ -1246,9 +1246,10 @@ def main(args):
         help='remove a test definition and all of its stored results',
         )
     subparser.add_argument(
-        '--test', '-t', metavar='name',
-        action='store', default='default',
-        help='name of test to remove (default is \'default\')',
+        '--test', '--tests', '-t', metavar='name',
+        action='store', dest='tests',
+        type=csv, default=['default'],
+        help='comma-separated name(s) of test(s) to remove (default is \'default\')',
         )
     add_verbosity_options(subparser)
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -63,68 +63,77 @@ import re
 import subprocess
 import argparse
 
-class AnsiColor:
-    BLACK = '\033[0;30m'
-    RED = '\033[0;31m'
-    GREEN = '\033[0;32m'
-    YELLOW = '\033[0;33m'
-    BLUE = '\033[0;34m'
-    MAGENTA = '\033[0;35m'
-    CYAN = '\033[0;36m'
-    B_GRAY = '\033[0;37m'
-    D_GRAY = '\033[1;30m'
-    B_RED = '\033[1;31m'
-    B_GREEN = '\033[1;32m'
-    B_YELLOW = '\033[1;33m'
-    B_BLUE = '\033[1;34m'
-    B_MAGENTA = '\033[1;35m'
-    B_CYAN = '\033[1;36m'
-    WHITE = '\033[1;37m'
+
+class AnsiColor(str):
     END = '\033[0m'
 
     @classmethod
     def disable(cls):
-        cls.BLACK = ''
-        cls.RED = ''
-        cls.GREEN = ''
-        cls.YELLOW = ''
-        cls.BLUE = ''
-        cls.MAGENTA = ''
-        cls.CYAN = ''
-        cls.B_GRAY = ''
-        cls.D_GRAY = ''
-        cls.B_RED = ''
-        cls.B_GREEN = ''
-        cls.B_YELLOW = ''
-        cls.B_BLUE = ''
-        cls.B_MAGENTA = ''
-        cls.B_CYAN = ''
-        cls.WHITE = ''
-        cls.END = ''
+        def nocolor(s):
+            return s
 
-def colored(text, color):
-    """Super simple function similar to colored from https://pypi.org/project/termcolor/
+        cls.BLACK = nocolor
+        cls.RED = nocolor
+        cls.GREEN = nocolor
+        cls.YELLOW = nocolor
+        cls.BLUE = nocolor
+        cls.MAGENTA = nocolor
+        cls.CYAN = nocolor
+        cls.B_GRAY = nocolor
+        cls.D_GRAY = nocolor
+        cls.B_RED = nocolor
+        cls.B_GREEN = nocolor
+        cls.B_YELLOW = nocolor
+        cls.B_BLUE = nocolor
+        cls.B_MAGENTA = nocolor
+        cls.B_CYAN = nocolor
+        cls.WHITE = nocolor
+        cls.END = nocolor
 
-    Example:
-    print('Save changes? ' + colored('Yes', AnsiColor.GREEN) + '/' + colored('No', AnsiColor.RED))
-    """
-    if text[-1] == '\n':
-        return color + text[:-1] + AnsiColor.END + '\n'
-    else:
-        return color + text + AnsiColor.END
+    def __call__(self, text):
+        """Return a string that displays 'text' in the color of 'self'.
+
+        Note that these calls don't nest correctly.
+
+        """
+
+        if text[-1] == '\n':
+            return self + text[:-1] + AnsiColor.END + '\n'
+        else:
+            return '%s%s%s' % (self, text, AnsiColor.END)
+
+
+# Define class-level constants for the colors:
+AnsiColor.BLACK = AnsiColor('\033[0;30m')
+AnsiColor.RED = AnsiColor('\033[0;31m')
+AnsiColor.GREEN = AnsiColor('\033[0;32m')
+AnsiColor.YELLOW = AnsiColor('\033[0;33m')
+AnsiColor.BLUE = AnsiColor('\033[0;34m')
+AnsiColor.MAGENTA = AnsiColor('\033[0;35m')
+AnsiColor.CYAN = AnsiColor('\033[0;36m')
+AnsiColor.B_GRAY = AnsiColor('\033[0;37m')
+AnsiColor.D_GRAY = AnsiColor('\033[1;30m')
+AnsiColor.B_RED = AnsiColor('\033[1;31m')
+AnsiColor.B_GREEN = AnsiColor('\033[1;32m')
+AnsiColor.B_YELLOW = AnsiColor('\033[1;33m')
+AnsiColor.B_BLUE = AnsiColor('\033[1;34m')
+AnsiColor.B_MAGENTA = AnsiColor('\033[1;35m')
+AnsiColor.B_CYAN = AnsiColor('\033[1;36m')
+AnsiColor.WHITE = AnsiColor('\033[1;37m')
+
 
 def good_bad_text(value):
     if value == 'good' or value == 'known-good':
-        return colored(value, AnsiColor.GREEN)
+        return AnsiColor.GREEN(value)
     if value == 'bad' or value == 'known-bad':
-        return colored(value, AnsiColor.RED)
+        return AnsiColor.RED(value)
     if value == 'unknown':
-        return colored(value, AnsiColor.YELLOW)
+        return AnsiColor.YELLOW(value)
     return value
 
 
 if not (0x02060000 <= sys.hexversion):
-    sys.stderr.write(colored('fatal: Python version 2.6 or later is required', AnsiColor.RED))
+    sys.stderr.write(AnsiColor.RED('fatal: Python version 2.6 or later is required'))
     sys.exit(125)
 
 
@@ -517,10 +526,10 @@ class Test(object):
         except UserTestError:
             sys.stdout.write('%s^{tree} %s\n' % (revision, good_bad_text('bad')))
             if verbosity >= -1:
-                sys.stderr.write(colored(FAIL_HEADER_TEMPLATE % dict(revision=revision), AnsiColor.RED))
+                sys.stderr.write(AnsiColor.RED(FAIL_HEADER_TEMPLATE % dict(revision=revision)))
                 cmd = ['git', '--no-pager', 'log', '-1', '--decorate', revision]
                 chatty_call(cmd, level=-1)
-                sys.stderr.write(colored(FAIL_TRAILER_TEMPLATE % dict(), AnsiColor.RED))
+                sys.stderr.write(AnsiColor.RED(FAIL_TRAILER_TEMPLATE % dict()))
                 self.write_status(revision, 'bad')
             raise
         else:
@@ -627,7 +636,7 @@ def cmd_add(parser, options):
                 # results and the user didn't explicitly ask for
                 # `--keep`; emit a warning in case the user forgot to
                 # `--forget`:
-                sys.stderr.write(colored(REUSE_RESULTS_WARNING % dict(name=test.name), AnsiColor.CYAN))
+                sys.stderr.write(AnsiColor.CYAN(REUSE_RESULTS_WARNING % dict(name=test.name)))
 
     if initialize:
         test.initialize_status('Test results initialized by \'git test add\'')
@@ -670,7 +679,7 @@ def cmd_run(parser, options):
     }
 
     if verbosity >= 0:
-        sys.stderr.write('Using test %s; command: %s\n' % (colored(test.name, AnsiColor.CYAN), colored(test.command, AnsiColor.CYAN)))
+        sys.stderr.write('Using test %s; command: %s\n' % (AnsiColor.CYAN(test.name), AnsiColor.CYAN(test.command)))
 
     try:
         require_clean_work_tree('test-run')
@@ -685,12 +694,12 @@ def cmd_run(parser, options):
         except UserTestError as e:
             sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
             if verbosity >= -1:
-                sys.stderr.write(colored('\n!!! TEST FAILED !!!\n', AnsiColor.RED))
+                sys.stderr.write(AnsiColor.RED('\n!!! TEST FAILED !!!\n'))
             sys.exit(e.returncode)
         else:
             sys.stdout.write('working-tree %s\n' % good_bad_text('good'))
             if verbosity >= -1:
-                sys.stderr.write(colored('\nTEST SUCCESSFUL\n', AnsiColor.GREEN))
+                sys.stderr.write(AnsiColor.GREEN('\nTEST SUCCESSFUL\n'))
         finally:
             sys.stderr.write(
                 'Note: working tree is dirty; results will not be saved.\n'
@@ -783,7 +792,7 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text), AnsiColor.RED))
+            sys.stderr.write(AnsiColor.RED('\n!!! %s %s FAILED !!!\n' % (fail_count, test_text)))
 
         if last_failure is not None:
             sys.exit(last_failure)
@@ -795,12 +804,12 @@ def cmd_run(parser, options):
                 test_text = 'TEST'
             else:
                 test_text = 'TESTS'
-            sys.stderr.write(colored('\n%s %s UNKNOWN\n' % (unknown_count, test_text), AnsiColor.YELLOW))
+            sys.stderr.write(AnsiColor.YELLOW('\n%s %s UNKNOWN\n' % (unknown_count, test_text)))
 
         sys.exit(2)
     else:
         if verbosity >= -1:
-            sys.stderr.write(colored('\nALL TESTS SUCCESSFUL\n', AnsiColor.GREEN))
+            sys.stderr.write(AnsiColor.GREEN('\nALL TESTS SUCCESSFUL\n'))
         return
 
 
@@ -1142,7 +1151,7 @@ if __name__ == '__main__':
     try:
         main(sys.argv[1:])
     except Fatal as e:
-        sys.stderr.write(colored('\nERROR!\n%s\n\n' % (e,), AnsiColor.RED))
+        sys.stderr.write(AnsiColor.RED('\nERROR!\n%s\n\n' % (e,)))
         sys.exit(125)
 
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -670,6 +670,24 @@ def iter_commits(parser, options):
             yield rev_parse('%s^{commit}' % (arg.strip(),))
 
 
+def run_in_dirty_tree(test, extra_env, options):
+    try:
+        test.run(extra_env=extra_env)
+    except UserTestError as e:
+        sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
+        if verbosity >= -1:
+            sys.stderr.write(AnsiColor.RED('\n!!! TEST FAILED !!!\n'))
+        sys.exit(e.returncode)
+    else:
+        sys.stdout.write('working-tree %s\n' % good_bad_text('good'))
+        if verbosity >= -1:
+            sys.stderr.write(AnsiColor.GREEN('\nTEST SUCCESSFUL\n'))
+    finally:
+        sys.stderr.write(
+            'Note: working tree is dirty; results will not be saved.\n'
+            )
+
+
 def cmd_run(parser, options):
     test = Test(options.test)
     extra_env = {
@@ -689,21 +707,7 @@ def cmd_run(parser, options):
         if options.commits or options.stdin or options.forget or options.dry_run:
             raise
 
-        try:
-            test.run(extra_env=extra_env)
-        except UserTestError as e:
-            sys.stdout.write('working-tree %s\n' % good_bad_text('bad'))
-            if verbosity >= -1:
-                sys.stderr.write(AnsiColor.RED('\n!!! TEST FAILED !!!\n'))
-            sys.exit(e.returncode)
-        else:
-            sys.stdout.write('working-tree %s\n' % good_bad_text('good'))
-            if verbosity >= -1:
-                sys.stderr.write(AnsiColor.GREEN('\nTEST SUCCESSFUL\n'))
-        finally:
-            sys.stderr.write(
-                'Note: working tree is dirty; results will not be saved.\n'
-                )
+        run_in_dirty_tree(test, extra_env, options)
         return
 
     revisions = list(uniqify(iter_commits(parser, options)))

--- a/bin/git-test
+++ b/bin/git-test
@@ -684,8 +684,12 @@ def run_in_dirty_tree(tests, extra_env, options):
                 )
                 if verbosity >= -1:
                     sys.stderr.write(
-                    '\n%s\n' % (
-                        AnsiColor.RED('!!! TEST \'%s\' FAILED !!!' % (test.name,)),
+                        '\n%s\n' % (
+                            AnsiColor.RED(
+                                '!!! TEST \'%s\' FAILED (retcode=%d) !!!' % (
+                                    test.name, e.returncode,
+                                ),
+                            ),
                         ),
                     )
                 fail_count += 1
@@ -784,7 +788,6 @@ def cmd_run(parser, options):
 
     fail_count = 0
     unknown_count = 0
-    last_failure = None
     for r in revisions:
         cmd = ['git', 'rev-parse', '--short', r]
         rs = check_output(cmd).rstrip()
@@ -861,9 +864,8 @@ def cmd_run(parser, options):
 
                     test.write_status(r, 'bad')
 
-                    failed_tests.append('%s:bad' % (test.name,))
+                    failed_tests.append('%s:bad:retcode=%d' % (test.name, e.returncode,))
                     fail_count += 1
-                    last_failure = e.returncode
 
                     if not options.keep_going:
                         if verbosity >= -1:
@@ -945,10 +947,7 @@ def cmd_run(parser, options):
             )
 
     if fail_count > 0:
-        if last_failure is not None:
-            sys.exit(last_failure)
-        else:
-            sys.exit(1)
+        sys.exit(1)
     elif unknown_count > 0:
         sys.exit(2)
 

--- a/bin/git-test
+++ b/bin/git-test
@@ -986,18 +986,18 @@ def cmd_results(parser, options):
 
 
 def cmd_forget_results(parser, options):
-    test = Test(options.test)
-
-    cmd = ['git', 'config', 'test.%s.command' % (test.name,)]
-    try:
-        chatty_call(cmd)
-    except CalledProcessError:
-        # There is no test defined; simply delete the notes reference:
-        test.remove_status('Test results deleted by \'git test forget-results\'')
-    else:
-        test.initialize_status(
-            'Test results reinitialized by \'git test forget-results\''
-            )
+    tests = [Test(test_name) for test_name in options.tests]
+    for test in tests:
+        cmd = ['git', 'config', 'test.%s.command' % (test.name,)]
+        try:
+            chatty_call(cmd)
+        except CalledProcessError:
+            # There is no test defined; simply delete the notes reference:
+            test.remove_status('Test results deleted by \'git test forget-results\'')
+        else:
+            test.initialize_status(
+                'Test results reinitialized by \'git test forget-results\''
+                )
 
 
 test_re = re.compile(r'^test\.(?P<name>.*)\.command$')
@@ -1219,9 +1219,13 @@ def main(args):
         help='permanently forget stored results for a test',
         )
     subparser.add_argument(
-        '--test', '-t', metavar='name',
-        action='store', default='default',
-        help='name of test whose results should be forgotten (default is \'default\')',
+        '--test', '--tests', '-t', metavar='name',
+        action='store', dest='tests',
+        type=csv, default=['default'],
+        help=(
+            'comma-separated name(s) of test(s) whose results should be '
+            'forgotten (default is \'default\')'
+            ),
         )
     add_verbosity_options(subparser)
 

--- a/test/run.t
+++ b/test/run.t
@@ -331,13 +331,13 @@ test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 	test_must_fail git notes --ref=tests/default show $c4^{tree}
 '
 
-test_expect_success 'default (failing-4-7-8): cannot test dirty working copy woth --dry-run' '
+test_expect_success 'default (failing-4-7-8): cannot test dirty working copy with --dry-run' '
 	echo 111 >number &&
 	test_when_finished "git reset --hard HEAD" &&
 	test_expect_code 125 git-test run --dry-run
 '
 
-test_expect_success 'default (failing-4-7-8): cannot test dirty working copy woth --forget' '
+test_expect_success 'default (failing-4-7-8): cannot test dirty working copy with --forget' '
 	echo 111 >number &&
 	test_when_finished "git reset --hard HEAD" &&
 	test_expect_code 125 git-test run --forget

--- a/test/run.t
+++ b/test/run.t
@@ -36,7 +36,12 @@ test_expect_success 'Set up test repository' '
 test_expect_success 'default (passing): test range' '
 	git-test add "test-number --log=numbers.log --good \*" &&
 	rm -f numbers.log &&
-	gen_stdout c3 good c4 good c5 good c6 good >expected-stdout &&
+	gen_stdout \
+		   c3 "good (default:good)" \
+		   c4 "good (default:good)" \
+		   c5 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run c2..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 3 4 5 6 >expected &&
@@ -51,7 +56,10 @@ test_expect_success 'default (passing): test range' '
 
 test_expect_success 'default (passing): do not re-test known-good commits' '
 	rm -f numbers.log &&
-	gen_stdout c4 known-good c5 known-good >expected-stdout &&
+	gen_stdout \
+		   c4 "good (default:known-good)" \
+		   c5 "good (default:known-good)" \
+		   >expected-stdout &&
 	git-test run c3..c5 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	test_must_fail test -f numbers.log
@@ -59,7 +67,14 @@ test_expect_success 'default (passing): do not re-test known-good commits' '
 
 test_expect_success 'default (passing): do not re-test known-good subrange' '
 	rm -f numbers.log &&
-	gen_stdout c2 good c3 known-good c4 known-good c5 known-good c6 known-good c7 good >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:good)" \
+		   c3 "good (default:known-good)" \
+		   c4 "good (default:known-good)" \
+		   c5 "good (default:known-good)" \
+		   c6 "good (default:known-good)" \
+		   c7 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run c1..c7 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 2 7 >expected &&
@@ -68,7 +83,16 @@ test_expect_success 'default (passing): do not re-test known-good subrange' '
 
 test_expect_success 'default (passing): do not retest known-good even with --retest' '
 	rm -f numbers.log &&
-	gen_stdout c1 good c2 known-good c3 known-good c4 known-good c5 known-good c6 known-good c7 known-good c8 good >expected-stdout &&
+	gen_stdout \
+		   c1 "good (default:good)" \
+		   c2 "good (default:known-good)" \
+		   c3 "good (default:known-good)" \
+		   c4 "good (default:known-good)" \
+		   c5 "good (default:known-good)" \
+		   c6 "good (default:known-good)" \
+		   c7 "good (default:known-good)" \
+		   c8 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run --retest c0..c8 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 1 8 >expected &&
@@ -77,7 +101,12 @@ test_expect_success 'default (passing): do not retest known-good even with --ret
 
 test_expect_success 'default (passing): retest with --force' '
 	rm -f numbers.log &&
-	gen_stdout c6 good c7 good c8 good c9 good >expected-stdout &&
+	gen_stdout \
+		   c6 "good (default:good)" \
+		   c7 "good (default:good)" \
+		   c8 "good (default:good)" \
+		   c9 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run --force c5..c9 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 6 7 8 9 >expected &&
@@ -96,7 +125,13 @@ test_expect_success 'default (passing): forget some results' '
 
 test_expect_success 'default (passing): retest forgotten commits' '
 	rm -f numbers.log &&
-	gen_stdout c4 known-good c5 good c6 good c7 good c8 known-good >expected-stdout &&
+	gen_stdout \
+		   c4 "good (default:known-good)" \
+		   c5 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   c7 "good (default:good)" \
+		   c8 "good (default:known-good)" \
+		   >expected-stdout &&
 	git-test run c3..c8 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 5 6 7 >expected &&
@@ -106,7 +141,9 @@ test_expect_success 'default (passing): retest forgotten commits' '
 test_expect_success 'default (passing): test a single commit' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	gen_stdout c5 good >expected-stdout &&
+	gen_stdout \
+		   c5 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run c5 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 5 >expected &&
@@ -115,7 +152,12 @@ test_expect_success 'default (passing): test a single commit' '
 
 test_expect_success 'default (passing): test a few single commits' '
 	rm -f numbers.log &&
-	gen_stdout c2 good c6 good c5 known-good c4 good >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   c5 "good (default:known-good)" \
+		   c4 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run c2 c6 c5 c4 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 2 6 4 >expected &&
@@ -125,7 +167,11 @@ test_expect_success 'default (passing): test a few single commits' '
 test_expect_success 'default (passing): test a single commit and a range' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	gen_stdout c9 good c5 good c6 good >expected-stdout &&
+	gen_stdout \
+		   c9 "good (default:good)" \
+		   c5 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run c9 c4..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 9 5 6 >expected &&
@@ -135,7 +181,14 @@ test_expect_success 'default (passing): test a single commit and a range' '
 test_expect_success 'default (passing): commits uniqified' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	gen_stdout c5 good c6 good c8 good c4 good c7 good c9 good >expected-stdout &&
+	gen_stdout \
+		   c5 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   c8 "good (default:good)" \
+		   c4 "good (default:good)" \
+		   c7 "good (default:good)" \
+		   c9 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run c4..c6 c8 c5 c3..c9 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 5 6 8 4 7 9 >expected &&
@@ -145,7 +198,12 @@ test_expect_success 'default (passing): commits uniqified' '
 test_expect_success 'default (passing): read commits from stdin' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	gen_stdout c6 good c5 good c4 good c3 good >expected-stdout &&
+	gen_stdout \
+		   c6 "good (default:good)" \
+		   c5 "good (default:good)" \
+		   c4 "good (default:good)" \
+		   c3 "good (default:good)" \
+		   >expected-stdout &&
 	git rev-list c2..c6 | git-test run --stdin >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 6 5 4 3 >expected &&
@@ -155,7 +213,13 @@ test_expect_success 'default (passing): read commits from stdin' '
 test_expect_success 'default (passing): combine args and stdin' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	gen_stdout c5 good c8 good c6 good c4 good c3 good >expected-stdout &&
+	gen_stdout \
+		   c5 "good (default:good)" \
+		   c8 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   c4 "good (default:good)" \
+		   c3 "good (default:good)" \
+		   >expected-stdout &&
 	git rev-list c2..c6 | git-test run --stdin c5 c8 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	# Note that rev-list was called without --reverse:
@@ -167,7 +231,10 @@ test_expect_success 'default (failing-4-7-8): test range' '
 	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 4 7 8 666 --good \*" &&
 	rm -f numbers.log &&
-	gen_stdout c3 good c4 bad >expected-stdout &&
+	gen_stdout \
+		   c3 "good (default:good)" \
+		   c4 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run c2..c5 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 3 4 >expected &&
@@ -182,7 +249,10 @@ test_expect_success 'default (failing-4-7-8): test range' '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known commits' '
 	rm -f numbers.log &&
-	gen_stdout c3 known-good c4 known-bad >expected-stdout &&
+	gen_stdout \
+		   c3 "good (default:known-good)" \
+		   c4 "bad (default:known-bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run c2..c5 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	test_must_fail test -f numbers.log
@@ -190,7 +260,11 @@ test_expect_success 'default (failing-4-7-8): do not re-test known commits' '
 
 test_expect_success 'default (failing-4-7-8): --dry-run' '
 	rm -f numbers.log &&
-	gen_stdout c2 unknown c3 known-good c4 known-bad >expected-stdout &&
+	gen_stdout \
+		   c2 "unknown (default:unknown)" \
+		   c3 "good (default:known-good)" \
+		   c4 "bad (default:known-bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --dry-run c1..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	test_must_fail test -f numbers.log
@@ -198,7 +272,13 @@ test_expect_success 'default (failing-4-7-8): --dry-run' '
 
 test_expect_success 'default (failing-4-7-8): --dry-run --keep-going' '
 	rm -f numbers.log &&
-	gen_stdout c2 unknown c3 known-good c4 known-bad c5 unknown c6 unknown >expected-stdout &&
+	gen_stdout \
+		   c2 "unknown (default:unknown)" \
+		   c3 "good (default:known-good)" \
+		   c4 "bad (default:known-bad)" \
+		   c5 "unknown (default:unknown)" \
+		   c6 "unknown (default:unknown)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --dry-run --keep-going c1..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	test_must_fail test -f numbers.log
@@ -206,7 +286,11 @@ test_expect_success 'default (failing-4-7-8): --dry-run --keep-going' '
 
 test_expect_success 'default (failing-4-7-8): do not re-test known subrange' '
 	rm -f numbers.log &&
-	gen_stdout c2 good c3 known-good c4 known-bad >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:good)" \
+		   c3 "good (default:known-good)" \
+		   c4 "bad (default:known-bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run c1..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 2 >expected &&
@@ -215,7 +299,11 @@ test_expect_success 'default (failing-4-7-8): do not re-test known subrange' '
 
 test_expect_success 'default (failing-4-7-8): retest known-bad with --retest' '
 	rm -f numbers.log &&
-	gen_stdout c2 known-good c3 known-good c4 bad >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:known-good)" \
+		   c3 "good (default:known-good)" \
+		   c4 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --retest c1..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 4 >expected &&
@@ -226,7 +314,10 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 	# Test a good commit past the failing one:
 	git-test run c5..c6 &&
 	rm -f numbers.log &&
-	gen_stdout c3 good c4 bad >expected-stdout &&
+	gen_stdout \
+		   c3 "good (default:good)" \
+		   c4 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --force c2..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 3 4 >expected &&
@@ -239,7 +330,15 @@ test_expect_success 'default (failing-4-7-8): retest with --force' '
 test_expect_success 'default (failing-4-7-8): test --keep-going' '
 	git-test forget-results &&
 	rm -f numbers.log &&
-	gen_stdout c3 good c4 bad c5 good c6 good c7 bad c8 bad c9 good >expected-stdout &&
+	gen_stdout \
+		   c3 "good (default:good)" \
+		   c4 "bad (default:bad)" \
+		   c5 "good (default:good)" \
+		   c6 "good (default:good)" \
+		   c7 "bad (default:bad)" \
+		   c8 "bad (default:bad)" \
+		   c9 "good (default:good)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --keep-going c2..c9 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 3 4 5 6 7 8 9 >expected &&
@@ -259,7 +358,15 @@ test_expect_success 'default (failing-4-7-8): test --keep-going' '
 
 test_expect_success 'default (failing-4-7-8): retest disjoint commits with --keep-going' '
 	rm -f numbers.log &&
-	gen_stdout c3 known-good c4 bad c5 known-good c6 known-good c7 bad c8 bad c9 known-good >expected-stdout &&
+	gen_stdout \
+		   c3 "good (default:known-good)" \
+		   c4 "bad (default:bad)" \
+		   c5 "good (default:known-good)" \
+		   c6 "good (default:known-good)" \
+		   c7 "bad (default:bad)" \
+		   c8 "bad (default:bad)" \
+		   c9 "good (default:known-good)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --retest --keep-going c2..c9 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 4 7 8 >expected &&
@@ -271,7 +378,9 @@ test_expect_success 'default (failing-4-7-8): test passing HEAD' '
 	rm -f numbers.log &&
 	git checkout c2 &&
 	git symbolic-ref HEAD >expected-branch &&
-	gen_stdout c2 good >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:good)" \
+		   >expected-stdout &&
 	git-test run >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
@@ -287,7 +396,9 @@ test_expect_success 'default (failing-4-7-8): test failing HEAD' '
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
-	gen_stdout c4 bad >expected-stdout &&
+	gen_stdout \
+		   c4 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
@@ -303,7 +414,9 @@ test_expect_success 'default (failing-4-7-8): test failing explicit HEAD' '
 	rm -f numbers.log &&
 	git checkout c4 &&
 	git symbolic-ref HEAD >expected-branch &&
-	gen_stdout c4 bad >expected-stdout &&
+	gen_stdout \
+		   c4 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run HEAD >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
@@ -322,7 +435,7 @@ test_expect_success 'default (failing-4-7-8): test passing dirty working copy' '
 	echo 42 >number &&
 	test_when_finished "git reset --hard HEAD" &&
 	git-test run >actual-stdout &&
-	echo "working-tree good" >expected-stdout &&
+	echo "working-tree good (default:good)" >expected-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
@@ -351,7 +464,7 @@ test_expect_success 'default (failing-4-7-8): test failing dirty working copy' '
 	echo 666 >number &&
 	test_when_finished "git reset --hard HEAD" &&
 	test_expect_code 1 git-test run >actual-stdout &&
-	echo "working-tree bad" >expected-stdout &&
+	echo "working-tree bad (default:bad)" >expected-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	git symbolic-ref HEAD >actual-branch &&
 	test_cmp expected-branch actual-branch &&
@@ -364,7 +477,10 @@ test_expect_success 'default (retcodes): test range' '
 	git-test forget-results &&
 	git-test add "test-number --log=numbers.log --bad 3 7 --ret=42 5 --good \*" &&
 	rm -f numbers.log &&
-	gen_stdout c4 good c5 bad >expected-stdout &&
+	gen_stdout \
+		   c4 "good (default:good)" \
+		   c5 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 42 git-test run c3..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 4 5 >expected &&
@@ -374,7 +490,10 @@ test_expect_success 'default (retcodes): test range' '
 test_expect_success 'default (retcodes): test range again' '
 	# We do not remember return codes (should we?):
 	rm -f numbers.log &&
-	gen_stdout c4 known-good c5 known-bad >expected-stdout &&
+	gen_stdout \
+		   c4 "good (default:known-good)" \
+		   c5 "bad (default:known-bad)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run c3..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	test_must_fail test -f numbers.log
@@ -382,7 +501,10 @@ test_expect_success 'default (retcodes): test range again' '
 
 test_expect_success 'default (retcodes): retest range' '
 	rm -f numbers.log &&
-	gen_stdout c4 known-good c5 bad >expected-stdout &&
+	gen_stdout \
+		   c4 "good (default:known-good)" \
+		   c5 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 42 git-test run --retest c3..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 5 >expected &&
@@ -391,7 +513,10 @@ test_expect_success 'default (retcodes): retest range' '
 
 test_expect_success 'default (retcodes): force test range' '
 	rm -f numbers.log &&
-	gen_stdout c4 good c5 bad >expected-stdout &&
+	gen_stdout \
+		   c4 "good (default:good)" \
+		   c5 "bad (default:bad)" \
+		   >expected-stdout &&
 	test_expect_code 42 git-test run --force c3..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 4 5 >expected &&
@@ -400,7 +525,15 @@ test_expect_success 'default (retcodes): force test range' '
 
 test_expect_success 'default (retcodes): list results' '
 	rm -f numbers.log &&
-	gen_stdout c2 unknown c3 unknown c4 known-good c5 known-bad c6 unknown c7 unknown c8 unknown >expected-stdout &&
+	gen_stdout \
+		   c2 "unknown (default:unknown)" \
+		   c3 "unknown (default:unknown)" \
+		   c4 "good (default:known-good)" \
+		   c5 "bad (default:known-bad)" \
+		   c6 "unknown (default:unknown)" \
+		   c7 "unknown (default:unknown)" \
+		   c8 "unknown (default:unknown)" \
+		   >expected-stdout &&
 	git-test results c1..c8 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	test_must_fail test -f numbers.log
@@ -408,7 +541,13 @@ test_expect_success 'default (retcodes): list results' '
 
 test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 	rm -f numbers.log &&
-	gen_stdout c2 good c3 bad c4 good c5 bad c6 good >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:good)" \
+		   c3 "bad (default:bad)" \
+		   c4 "good (default:good)" \
+		   c5 "bad (default:bad)" \
+		   c6 "good (default:good)" \
+		   >expected-stdout &&
 	test_expect_code 42 git-test run --force --keep-going c1..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 2 3 4 5 6 >expected &&
@@ -417,7 +556,15 @@ test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 
 test_expect_success 'default (retcodes): keep-going: bad wins if last' '
 	rm -f numbers.log &&
-	gen_stdout c2 good c3 bad c4 good c5 bad c6 good c7 bad c8 good >expected-stdout &&
+	gen_stdout \
+		   c2 "good (default:good)" \
+		   c3 "bad (default:bad)" \
+		   c4 "good (default:good)" \
+		   c5 "bad (default:bad)" \
+		   c6 "good (default:good)" \
+		   c7 "bad (default:bad)" \
+		   c8 "good (default:good)" \
+		   >expected-stdout &&
 	test_expect_code 1 git-test run --force --keep-going c1..c8 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 2 3 4 5 6 7 8 >expected &&

--- a/test/run.t
+++ b/test/run.t
@@ -539,7 +539,7 @@ test_expect_success 'default (retcodes): list results' '
 	test_must_fail test -f numbers.log
 '
 
-test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
+test_expect_success 'default (retcodes): keep-going: retcode is always 1' '
 	rm -f numbers.log &&
 	gen_stdout \
 		   c2 "good (default:good)" \
@@ -548,7 +548,7 @@ test_expect_success 'default (retcodes): keep-going: retcode wins if last' '
 		   c5 "bad (default:bad)" \
 		   c6 "good (default:good)" \
 		   >expected-stdout &&
-	test_expect_code 42 git-test run --force --keep-going c1..c6 >actual-stdout &&
+	test_expect_code 1 git-test run --force --keep-going c1..c6 >actual-stdout &&
 	test_cmp expected-stdout actual-stdout &&
 	printf "default %s${LF}" 2 3 4 5 6 >expected &&
 	test_cmp expected numbers.log

--- a/test/run.t
+++ b/test/run.t
@@ -528,8 +528,8 @@ test_expect_success 'default (retcodes): list results' '
 	gen_stdout \
 		   c2 "unknown (default:unknown)" \
 		   c3 "unknown (default:unknown)" \
-		   c4 "good (default:known-good)" \
-		   c5 "bad (default:known-bad)" \
+		   c4 "good (default:good)" \
+		   c5 "bad (default:bad)" \
 		   c6 "unknown (default:unknown)" \
 		   c7 "unknown (default:unknown)" \
 		   c8 "unknown (default:unknown)" \


### PR DESCRIPTION
This is a riff on https://github.com/mhagger/git-test/pull/24. Thanks to @hlovdal for that contribution, from which I borrowed heavily!

Compared to that PR, I have tried to make the new output more consistent and informative without being overwhelming. But I also went through most of the implementation again and revised it quite a bit. I preserved the authorship of commits that retained the flavor of the original even though they are somewhat transformed; @hlovdal let me know if you have any objections!

With this change, you can run multiple tests at the same time by feeding multiple test names to the `--test` (or `-t` or `--tests`) option, like

    git test run --test=test1,test2 commit1..commit2

This checks out the commits as before, one by one, but for each commit it runs all of the specified tests. If any of the tests fail, the commit is considered bad. The good/bad status is recorded for each (commit, test) pair, in Git notes named after the individual tests.

The stdout is changed somewhat; now each line has a third field explaining which test failed; for example,

    3d9ec13248e904ef0279b54450a5c89f211d2174^{tree} bad (test1:bad)

There is one such line per (commit, test) pair.

`git test results`, when applied to multiple tests, outputs one line per commit of the form

    ca061fd40c0759fa02a756ae527dc4e172d4837f^{tree} bad (test1:known-bad test2:good)
    5c2c8173f7cc866a6eb160f8222a1a7695d730b9^{tree} bad (test1:bad test2:good)

The stderr should mostly be self-explanatory. If a commit is found to be bad, the bad commit and its log messages are printed out as usual. But now, the header says what tests failed and what their individual return codes were:

```
*******************************************************************************
BAD COMMIT 5c2c8173f7cc866a6eb160f8222a1a7695d730b9: (failing:test1:retcode=1,test2:bad:retcode=13)

commit 5c2c8173f7cc866a6eb160f8222a1a7695d730b9 (HEAD, origin/multi-tests-v2, multi-tests-v2)
[...]
```

The last thing output is the overall success or failure of _all_ tests over _all_ commits so that it's obvious whether everything was OK or whether there was a problem:

```
!!! 4 TESTS FAILED !!!
```

One other change is that, if `--keep-going` is specified, then `git-test` doesn't try to set its own exit code based on the exit code of the last failing test. This didn't seem like a useful feature, since multiple tests might have failed. But if `--keep-going` is _not_ specified, then the old behavior is preserved: the exit code of `git-test` is the same as that of the test that failed (if any).

@hlovdal if you are interested to give this a try, let me know what you think. Since you've obviously used this kind of functionality before, you might notice if something important is missing or inconvenient.
